### PR TITLE
fix: point Sponsor button at OpenFlow's own Buy Me a Coffee

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,5 @@
-github: cjpais
-custom: ["https://handy.computer/donate", "https://www.paypal.me/cjpais"]
-buy_me_a_coffee: cjpais
-ko_fi: cjpais
+# OpenFlow funding. The repo "Sponsor" button reads this file (not your GitHub
+# Sponsors settings), so it must list OpenFlow's own links — not the upstream
+# Handy author's. avijeett007 has no GitHub Sponsors listing, so no `github:`
+# entry (it would render a broken link); add one here if that changes.
+buy_me_a_coffee: kno2gether

--- a/README.md
+++ b/README.md
@@ -126,10 +126,7 @@ Code signing and notarization (an Apple Developer ID certificate, Windows Authen
 
 If OpenFlow saves you time, consider supporting its development:
 
-- [GitHub Sponsors](https://github.com/sponsors/avijeett007)
-- [Buy Me a Coffee](https://buymeacoffee.com/)
-
-<!-- Maintainer: please confirm/replace these donation links before publicizing them. -->
+- [Buy Me a Coffee](https://buymeacoffee.com/kno2gether)
 
 ## Adding a provider
 


### PR DESCRIPTION
## What

The GitHub **Sponsor** button was still showing the upstream Handy author (`cjpais`) — GitHub Sponsors + handy.computer/donate + paypal.me/cjpais + ko-fi. That's because the button reads `.github/FUNDING.yml`, which was inherited from Handy and never updated.

This replaces it with OpenFlow's own funding link: **buymeacoffee.com/kno2gether**.

## Why no `github:` entry

`avijeett007` has no GitHub Sponsors listing (`hasSponsorsListing: false`), so a `github:` line would render a broken/empty Sponsors entry. Add one later if that changes.

## Test plan

- FUNDING.yml is valid YAML with a single `buy_me_a_coffee: kno2gether` key.
- After merge, the repo **Sponsor** button shows only "Buy Me a Coffee → kno2gether".

🤖 Generated with [Claude Code](https://claude.com/claude-code)