### PR TITLE
chore: bump version to 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openflow-app",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "homepage": "https://openflow.computer",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "openflow"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openflow"
-version = "0.9.1"
+version = "0.9.2"
 description = "OpenFlow"
 authors = ["cjpais", "OpenFlow"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenFlow",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "knotie.ai.openflow",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Version bump for the v0.9.2 release: hands-free smart-VAD fix + full de-Handy branding + openflow.computer domain/About links, shipped consistently across macOS (arm64 + Intel) and Windows.

Verified locally: full Intel release build compiles and bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)