### PR TITLE
fix(hands-free): Intel-Mac Auto accelerator + surface silent failures

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -562,6 +562,7 @@ pub fn run(cli_args: CliArgs) {
             shortcut::set_wake_word_sensitivity,
             shortcut::set_wake_word_listen_seconds,
             shortcut::set_wake_word_silence_timeout_seconds,
+            shortcut::get_hands_free_readiness,
             shortcut::change_audio_feedback_setting,
             shortcut::change_audio_feedback_volume_setting,
             shortcut::change_sound_theme_setting,

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -1748,10 +1748,27 @@ fn resolve_device_index(index: usize) -> Result<(Backend, i32)> {
 /// strict CPU. `Gpu` requests the platform GPU backend, but only if a device for
 /// it is actually registered — otherwise it falls back to `Auto` so the load
 /// never fails outright on a machine without that GPU backend.
+///
+/// Intel-Mac exception: on `x86_64` macOS, `Auto` resolves to `Cpu` instead of
+/// `Backend::Auto`. transcribe-cpp's Auto (and Metal) pick the Metal backend on
+/// Intel Macs, where loading a gguf model fails deterministically every cycle
+/// with "gguf load error (status 4)" (observed with parakeet-unified Q8_0) —
+/// which is exactly what silently broke hands-free. CPU there runs ~7x realtime
+/// and works end-to-end. Apple-silicon Macs keep Metal via `Auto`, and an
+/// explicit `Gpu`/Metal selection is still honored below.
 fn select_transcribe_backend(setting: TranscribeAcceleratorSetting) -> Backend {
     match setting {
         TranscribeAcceleratorSetting::Cpu => Backend::Cpu,
-        TranscribeAcceleratorSetting::Auto => Backend::Auto,
+        TranscribeAcceleratorSetting::Auto => {
+            #[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+            {
+                Backend::Cpu
+            }
+            #[cfg(not(all(target_os = "macos", not(target_arch = "aarch64"))))]
+            {
+                Backend::Auto
+            }
+        }
         TranscribeAcceleratorSetting::Gpu => {
             #[cfg(target_os = "macos")]
             let candidates = [Backend::Metal];
@@ -1925,6 +1942,26 @@ mod tests {
         assert!(matches!(plan.task, Task::Transcribe));
         assert_eq!(plan.language.as_deref(), Some("es"));
         assert_eq!(plan.target_language, None);
+    }
+
+    #[test]
+    fn select_backend_cpu_is_always_strict_cpu() {
+        assert_eq!(
+            select_transcribe_backend(TranscribeAcceleratorSetting::Cpu),
+            Backend::Cpu
+        );
+    }
+
+    #[test]
+    fn select_backend_auto_is_cpu_on_intel_mac_else_auto() {
+        // Intel Macs: Auto must resolve to Cpu (Metal gguf loads fail there,
+        // "gguf load error (status 4)"). Everywhere else Auto stays Backend::Auto
+        // (which yields Metal on Apple silicon, CUDA/Vulkan/CPU elsewhere).
+        let resolved = select_transcribe_backend(TranscribeAcceleratorSetting::Auto);
+        #[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+        assert_eq!(resolved, Backend::Cpu);
+        #[cfg(not(all(target_os = "macos", not(target_arch = "aarch64"))))]
+        assert_eq!(resolved, Backend::Auto);
     }
 }
 

--- a/src-tauri/src/managers/wake_word.rs
+++ b/src-tauri/src/managers/wake_word.rs
@@ -25,6 +25,15 @@
 //! mid-thought. This replaces the old fixed-window capture. Note the *detection*
 //! windows are still fixed short cycles — a single always-open rolling stream for
 //! detection is the next refinement.
+//!
+//! Failure handling: wake-word detection ALWAYS needs a local STT model (even for
+//! users who dictate via a remote backend). When the selected local model is
+//! missing/unloadable the loop would otherwise fail every cycle in silence, so we
+//! surface the problem: on the first failure of a streak we emit a
+//! `hands-free-error` Tauri event (payload `"model"` / `"transcription"` /
+//! `"microphone"`) the UI turns into a banner, and after a few consecutive
+//! failures we back off hard ([`PERSISTENT_ERROR_SLEEP`]) so a hopeless loop stops
+//! reopening the mic every few seconds forever.
 
 use crate::actions::finish_dictation;
 use crate::audio_toolkit::VadPolicy;
@@ -35,7 +44,7 @@ use log::{debug, error, info};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 
 /// Synthetic binding id used when the wake-word loop drives the shared recorder,
 /// so it never collides with a real user hotkey binding.
@@ -59,6 +68,36 @@ const IDLE_SLEEP: Duration = Duration::from_millis(400);
 
 /// Longer backoff after an error (e.g. no local model loaded) to avoid log spam.
 const ERROR_SLEEP: Duration = Duration::from_millis(1500);
+
+/// Number of consecutive per-cycle failures that flips the loop from the normal
+/// [`ERROR_SLEEP`] back-off to the much longer [`PERSISTENT_ERROR_SLEEP`].
+const PERSISTENT_ERROR_THRESHOLD: u32 = 3;
+
+/// Back-off once a failure looks persistent (e.g. the selected local model is
+/// missing and every `transcribe` fails). Far longer than [`ERROR_SLEEP`] so a
+/// hopeless loop stops reopening the mic every ~5s forever until the user fixes
+/// the underlying problem (which restarts the listener fresh).
+const PERSISTENT_ERROR_SLEEP: Duration = Duration::from_secs(30);
+
+/// Emit the `hands-free-error` event the settings UI turns into a banner. `kind`
+/// is one of `"model"`, `"transcription"`, or `"microphone"`. Matches the plain
+/// string-payload emit pattern used elsewhere (e.g. `actions.rs`
+/// `"transcription-error"`).
+fn emit_hands_free_error(app: &AppHandle, kind: &str) {
+    let _ = app.emit("hands-free-error", kind);
+}
+
+/// Classify a transcription error string into the `hands-free-error` payload the
+/// UI maps to a message. A missing/unloadable local model surfaces as `"model"`
+/// (the common hands-free failure — detection always needs a local model); any
+/// other failure is a generic `"transcription"` error.
+fn classify_wake_error(err: &str) -> &'static str {
+    if err.to_lowercase().contains("model") {
+        "model"
+    } else {
+        "transcription"
+    }
+}
 
 pub struct WakeWordManager {
     app: AppHandle,
@@ -112,6 +151,15 @@ impl WakeWordManager {
 }
 
 fn wake_word_loop(app: AppHandle, running: Arc<AtomicBool>) {
+    // Failure-streak state. Declared here (not persisted) so a fresh listener
+    // start always begins with a clean slate: no lingering error banner cause and
+    // the normal back-off. `*_emitted` flags de-dupe the `hands-free-error` event
+    // so a persistent failure emits once per streak, not every cycle.
+    let mut transcription_failures: u32 = 0;
+    let mut transcription_error_emitted = false;
+    let mut mic_failures: u32 = 0;
+    let mut mic_error_emitted = false;
+
     while running.load(Ordering::SeqCst) {
         let settings = get_settings(&app);
         // The setting is the source of truth; honor an out-of-band disable.
@@ -136,20 +184,59 @@ fn wake_word_loop(app: AppHandle, running: Arc<AtomicBool>) {
 
         // Capture one listening window and transcribe it.
         let samples = match capture_window(&rm, &running, LISTEN_WINDOW_MS) {
-            Some(s) if !s.is_empty() => s,
-            _ => {
+            // Recorder started and produced audio — clear any mic-failure streak.
+            Some(s) if !s.is_empty() => {
+                mic_failures = 0;
+                mic_error_emitted = false;
+                s
+            }
+            // Recorder started but the window was silence — not a mic failure.
+            Some(_) => {
+                mic_failures = 0;
+                mic_error_emitted = false;
+                std::thread::sleep(IDLE_SLEEP);
+                continue;
+            }
+            // Recorder could not start. A one-off is usually benign contention (a
+            // manual dictation grabbed it), so only surface it once the failure
+            // looks persistent — then emit "microphone" a single time per streak.
+            None => {
+                mic_failures = mic_failures.saturating_add(1);
+                if mic_failures >= PERSISTENT_ERROR_THRESHOLD && !mic_error_emitted {
+                    emit_hands_free_error(&app, "microphone");
+                    mic_error_emitted = true;
+                }
                 std::thread::sleep(IDLE_SLEEP);
                 continue;
             }
         };
 
         let transcript = match tm.transcribe(samples.clone()) {
-            Ok(t) => t,
+            Ok(t) => {
+                // Success — clear the failure streak so the next error emits again
+                // and the loop returns to the normal cadence/back-off.
+                transcription_failures = 0;
+                transcription_error_emitted = false;
+                t
+            }
             Err(e) => {
-                // Non-fatal: log and back off. Most common cause is no local model
-                // loaded (e.g. user only configured a remote STT backend).
+                // Non-fatal per cycle, but the common cause is a missing/unloadable
+                // local model (wake-word detection always needs one, even for
+                // remote-STT users), which fails every cycle. Surface it once per
+                // streak and back off harder once it looks persistent so we stop
+                // reopening the mic every ~5s in vain.
+                transcription_failures = transcription_failures.saturating_add(1);
+                if !transcription_error_emitted {
+                    emit_hands_free_error(&app, classify_wake_error(&e.to_string()));
+                    transcription_error_emitted = true;
+                }
                 debug!("Wake-word listen transcription failed: {}", e);
-                std::thread::sleep(ERROR_SLEEP);
+                let backoff = if transcription_failures >= PERSISTENT_ERROR_THRESHOLD {
+                    PERSISTENT_ERROR_SLEEP
+                } else {
+                    ERROR_SLEEP
+                };
+                std::thread::sleep(backoff);
                 continue;
             }
         };
@@ -486,5 +573,26 @@ mod tests {
     fn empty_inputs_do_not_match() {
         assert!(match_wake_word("", "hey flow", 0.8).is_none());
         assert!(match_wake_word("hey flow", "", 0.8).is_none());
+    }
+
+    #[test]
+    fn classify_wake_error_flags_model_failures() {
+        // The real-world missing-model failure string.
+        assert_eq!(
+            classify_wake_error("model load failed: gguf load error (status 4)"),
+            "model"
+        );
+        // Case-insensitive.
+        assert_eq!(classify_wake_error("MODEL not found"), "model");
+        assert_eq!(classify_wake_error("Failed to load Model file"), "model");
+    }
+
+    #[test]
+    fn classify_wake_error_defaults_to_transcription() {
+        assert_eq!(
+            classify_wake_error("engine returned empty output"),
+            "transcription"
+        );
+        assert_eq!(classify_wake_error(""), "transcription");
     }
 }

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -545,6 +545,44 @@ pub fn set_wake_word_silence_timeout_seconds(app: AppHandle, seconds: f32) -> Re
     Ok(())
 }
 
+/// Readiness of the hands-free wake-word listener: whether the currently selected
+/// local STT model is downloaded on disk. Wake-word *detection* always needs a
+/// local model, even for users who dictate via a remote STT backend, so the UI
+/// warns when it's missing (detection — and therefore dictation — can't work).
+#[derive(Serialize, Type)]
+pub struct HandsFreeReadiness {
+    /// Whether the selected model exists on disk and can drive detection.
+    local_model_available: bool,
+    /// The currently selected model id, or `None` if nothing is selected.
+    selected_model: Option<String>,
+}
+
+/// Report whether hands-free wake-word detection can actually run: it needs the
+/// selected local STT model present on disk. Reuses [`ModelManager`]'s existing
+/// on-disk `is_downloaded` view rather than probing files here.
+#[tauri::command]
+#[specta::specta]
+pub fn get_hands_free_readiness(app: AppHandle) -> Result<HandsFreeReadiness, String> {
+    let selected = get_settings(&app).selected_model.trim().to_string();
+    let selected_model = if selected.is_empty() {
+        None
+    } else {
+        Some(selected)
+    };
+
+    let model_manager = app.state::<std::sync::Arc<crate::managers::model::ModelManager>>();
+    let local_model_available = selected_model
+        .as_ref()
+        .and_then(|id| model_manager.get_model_info(id))
+        .map(|info| info.is_downloaded)
+        .unwrap_or(false);
+
+    Ok(HandsFreeReadiness {
+        local_model_available,
+        selected_model,
+    })
+}
+
 #[tauri::command]
 #[specta::specta]
 pub fn change_audio_feedback_setting(app: AppHandle, enabled: bool) -> Result<(), String> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { Sidebar, SidebarSection, SECTIONS_CONFIG } from "./components/Sidebar";
 import { WhatsNewGate } from "./components/whats-new";
 import { useSettings } from "./hooks/useSettings";
 import { useSettingsStore } from "./stores/settingsStore";
+import { useNavigationStore } from "./stores/navigationStore";
 import { commands } from "@/bindings";
 import { getLanguageDirection, initializeRTL } from "@/lib/utils/rtl";
 
@@ -35,8 +36,10 @@ function App() {
   // Track if this is a returning user who just needs to grant permissions
   // (vs a new user who needs full onboarding including model selection)
   const [isReturningUser, setIsReturningUser] = useState(false);
-  const [currentSection, setCurrentSection] =
-    useState<SidebarSection>("general");
+  const currentSection = useNavigationStore((state) => state.currentSection);
+  const setCurrentSection = useNavigationStore(
+    (state) => state.setCurrentSection,
+  );
   const { settings, updateSetting } = useSettings();
   const direction = getLanguageDirection(i18n.language);
   const refreshAudioDevices = useSettingsStore(

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -84,6 +84,14 @@ async setWakeWordSilenceTimeoutSeconds(seconds: number) : Promise<Result<null, s
     else return { status: "error", error: e  as any };
 }
 },
+async getHandsFreeReadiness() : Promise<Result<HandsFreeReadiness, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_hands_free_readiness") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async changeAudioFeedbackSetting(enabled: boolean) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("change_audio_feedback_setting", { enabled }) };
@@ -1228,7 +1236,14 @@ export type EngineType =
  */
 "TranscribeCpp" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice" | "GigaAM" | "Canary" | "Cohere"
 export type GpuDeviceOption = { id: number; name: string; total_vram_mb: number }
-export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; post_process_requested: boolean }
+/**
+ * Readiness of the hands-free wake-word listener: whether the currently selected
+ * local STT model is downloaded on disk. Wake-word *detection* always needs a
+ * local model, even for users who dictate via a remote STT backend, so the UI
+ * warns when it's missing (detection — and therefore dictation — can't work).
+ */
+export type HandsFreeReadiness = { local_model_available: boolean; selected_model: string | null }
+export type HistoryEntry ={ id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null; post_process_requested: boolean }
 export type HistoryUpdatePayload = { action: "added"; entry: HistoryEntry } | { action: "updated"; entry: HistoryEntry } | { action: "deleted"; id: number } | { action: "toggled"; id: number }
 /**
  * Result of changing keyboard implementation

--- a/src/components/settings/hands-free/HandsFreeSettings.tsx
+++ b/src/components/settings/hands-free/HandsFreeSettings.tsx
@@ -1,22 +1,75 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check } from "lucide-react";
-import { commands } from "@/bindings";
+import { listen } from "@tauri-apps/api/event";
+import { AlertTriangle, Check } from "lucide-react";
+import { commands, type HandsFreeReadiness } from "@/bindings";
 import { useSettings } from "../../../hooks/useSettings";
+import { useNavigationStore } from "../../../stores/navigationStore";
 import { SettingsGroup } from "../../ui/SettingsGroup";
 import { SettingContainer } from "../../ui/SettingContainer";
 import { ToggleSwitch } from "../../ui/ToggleSwitch";
 import { Slider } from "../../ui/Slider";
 import { Input } from "../../ui/Input";
 import { Button } from "../../ui/Button";
+import { Alert } from "../../ui/Alert";
 
 export const HandsFreeSettings: React.FC = () => {
   const { t } = useTranslation();
   const { settings, refreshSettings } = useSettings();
+  const setCurrentSection = useNavigationStore(
+    (state) => state.setCurrentSection,
+  );
 
   const handsFreeEnabled = settings?.hands_free_enabled ?? false;
 
   const [isTogglingEnabled, setIsTogglingEnabled] = useState(false);
+
+  // Whether the selected local STT model is present on disk. Wake-word detection
+  // always needs one (even for remote-STT users), so we warn at the toggle when
+  // it's missing rather than failing silently in the background loop.
+  const [readiness, setReadiness] = useState<HandsFreeReadiness | null>(null);
+  // Latest runtime failure surfaced by the background loop's `hands-free-error`
+  // event (payload: "model" | "transcription" | "microphone").
+  const [runtimeError, setRuntimeError] = useState<string | null>(null);
+
+  const refreshReadiness = async () => {
+    const result = await commands.getHandsFreeReadiness();
+    if (result.status === "ok") {
+      setReadiness(result.data);
+    }
+  };
+
+  // Check readiness on mount, and whenever the persisted enabled/model changes.
+  useEffect(() => {
+    void refreshReadiness();
+  }, [settings?.hands_free_enabled, settings?.selected_model]);
+
+  // Surface runtime failures from the background listener as an error banner.
+  useEffect(() => {
+    const unlisten = listen<string>("hands-free-error", (event) => {
+      setRuntimeError(event.payload);
+      // A runtime failure may reflect a newly-missing model — re-check so the
+      // model-missing banner stays accurate.
+      void refreshReadiness();
+    });
+    return () => {
+      void unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const modelMissing =
+    handsFreeEnabled && readiness !== null && !readiness.local_model_available;
+
+  const runtimeErrorMessage = (payload: string): string => {
+    switch (payload) {
+      case "model":
+        return t("settings.handsFree.runtimeError.model");
+      case "microphone":
+        return t("settings.handsFree.runtimeError.microphone");
+      default:
+        return t("settings.handsFree.runtimeError.transcription");
+    }
+  };
 
   const [wakeWordInput, setWakeWordInput] = useState("");
   const [isSavingWakeWord, setIsSavingWakeWord] = useState(false);
@@ -45,9 +98,14 @@ export const HandsFreeSettings: React.FC = () => {
 
   const handleToggleEnabled = async (enabled: boolean) => {
     setIsTogglingEnabled(true);
+    // Disabling stops the listener, so any stale runtime error no longer applies.
+    if (!enabled) {
+      setRuntimeError(null);
+    }
     try {
       await commands.setHandsFreeEnabled(enabled);
       await refreshSettings();
+      await refreshReadiness();
     } finally {
       setIsTogglingEnabled(false);
     }
@@ -116,6 +174,31 @@ export const HandsFreeSettings: React.FC = () => {
           {t("settings.handsFree.description")}
         </p>
       </div>
+
+      {modelMissing && (
+        <div className="flex items-start gap-3 p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
+          <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5 text-yellow-500" />
+          <div className="flex-1 space-y-2">
+            <p className="text-sm font-semibold text-yellow-400">
+              {t("settings.handsFree.modelMissing.title")}
+            </p>
+            <p className="text-sm text-yellow-400/90">
+              {t("settings.handsFree.modelMissing.body")}
+            </p>
+            <Button
+              onClick={() => setCurrentSection("models")}
+              variant="secondary"
+              size="sm"
+            >
+              {t("settings.handsFree.modelMissing.cta")}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {runtimeError && !(modelMissing && runtimeError === "model") && (
+        <Alert variant="error">{runtimeErrorMessage(runtimeError)}</Alert>
+      )}
 
       <SettingsGroup>
         <ToggleSwitch

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -366,7 +366,17 @@
         "description": "Once you've started speaking, end the command this long after you go quiet. Lower feels snappier; higher tolerates longer pauses.",
         "unit": "{{count}}s"
       },
-      "tapToToggleHint": "Tip: even without hands-free, tapping the hotkey once (with Push-To-Talk off) starts listening hands-free until you tap it again — no holding required."
+      "tapToToggleHint": "Tip: even without hands-free, tapping the hotkey once (with Push-To-Talk off) starts listening hands-free until you tap it again — no holding required.",
+      "modelMissing": {
+        "title": "Local model required",
+        "body": "Wake-word detection needs a downloaded local speech model, even when you dictate with remote STT. Your selected model isn't on disk, so hands-free dictation can't work until you download one.",
+        "cta": "Go to Models"
+      },
+      "runtimeError": {
+        "model": "Hands-free stopped: the local speech model couldn't be loaded. Download or reselect a model, and if it persists try switching the accelerator to CPU under Settings → Advanced, then re-enable hands-free.",
+        "transcription": "Hands-free hit a transcription error while listening for the wake word. Check your model and microphone, then try again.",
+        "microphone": "Hands-free couldn't start the microphone. Check that no other app is using it and that microphone access is granted."
+      }
     },
     "sound": {
       "title": "Sound",

--- a/src/stores/navigationStore.ts
+++ b/src/stores/navigationStore.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+import type { SidebarSection } from "../components/Sidebar";
+
+// The active settings section is the single navigation state for the main app
+// window (the sidebar and content area both read it). Kept in a tiny store — as
+// opposed to App-local state — so components deep in the tree (e.g. the
+// hands-free "Go to Models" shortcut) can navigate without prop-drilling.
+interface NavigationStore {
+  currentSection: SidebarSection;
+  setCurrentSection: (section: SidebarSection) => void;
+}
+
+export const useNavigationStore = create<NavigationStore>((set) => ({
+  currentSection: "general",
+  setCurrentSection: (section) => set({ currentSection: section }),
+}));


### PR DESCRIPTION
## Problem
Hands-free (wake-word) mode did nothing when toggled on — completely silently. Diagnosed from the real app's logs + a live end-to-end test:

- The wake-word loop WAS running (mic opened 708× in one session), but **every** cycle failed at local transcription with `gguf load error (status 4)`.
- Root cause: `transcribe_accelerator: Auto` resolves to the **Metal** backend on all Macs — and on **Intel Macs** the gguf model load onto Metal fails deterministically. This also silently breaks manual local dictation on Intel.
- Proof: switching the accelerator to CPU (no code change) made the whole chain work end-to-end — wake match ("Hey Flo" fuzzy-accepted), command capture, LLM cleanup, paste, analytics. CPU runs ~7× realtime.
- Every failure was `debug!`-only: no banner, no event, toggle reports success.

## Fix
1. **transcription.rs** — `Auto` resolves to `Cpu` on x86_64 macOS (Apple Silicon keeps Metal; explicit Gpu/Metal selection untouched). Unit-tested.
2. **Never silent again (defense-in-depth):**
   - `wake_word.rs`: `hands-free-error` Tauri event on the first failure of a streak (`model`/`transcription`/`microphone`), escalating backoff (30s) after 3 consecutive failures so a hopeless loop stops reopening the mic every ~5s. Unit-tested error classification.
   - New `get_hands_free_readiness` command (uses ModelManager's `is_downloaded`, covering the shared HF cache) + amber "model missing" banner with a **Go to Models** button in Hands-free settings, and a runtime-error banner mapping the event payloads.
   - Small zustand `navigationStore` so the deep-tree button can navigate (App.tsx state moved there, same semantics).

## Verification
- `cargo test --lib`: 108 passed (incl. 2 new backend-mapping + 2 classifier tests); cargo check/fmt clean; tsc/eslint/prettier clean.
- Live E2E test on the failing machine (Intel Mac, default settings) confirmed the CPU path works; an independent verifier run on this branch with DEFAULT `Auto` follows before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)