### PR TITLE
chore: bump version to 0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openflow-app",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "homepage": "https://openflow.computer",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "openflow"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openflow"
-version = "0.9.2"
+version = "0.9.3"
 description = "OpenFlow"
 authors = ["cjpais", "OpenFlow"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenFlow",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "knotie.ai.openflow",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Release: hands-free fix — Auto accelerator now resolves to CPU on Intel Macs (fixes silent gguf-load failure breaking wake-word AND local dictation), plus visible error surfacing (readiness banner, hands-free-error events, escalating backoff). Independently verified end-to-end on the failing machine with default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)