### PR TITLE
fix: mouse-button hotkeys not suppressed system-wide (handy-keys 0.2.4 → 0.3.0)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -804,21 +804,6 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "core-foundation 0.9.4",
- "core-graphics 0.21.0",
- "foreign-types 0.3.2",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
@@ -921,21 +906,11 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
-dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -945,45 +920,15 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.7.0",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "foreign-types 0.3.2",
- "libc",
-]
 
 [[package]]
 name = "core-graphics"
@@ -1668,26 +1613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
-name = "evdev-rs"
-version = "0.4.0"
+name = "evdev"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92abc30d5fd1e4f6440dee4d626abc68f4a9b5014dc1de575901e23c2e02321"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
 dependencies = [
- "bitflags 1.3.2",
- "evdev-sys",
+ "bitvec",
+ "cfg-if",
  "libc",
- "log",
-]
-
-[[package]]
-name = "evdev-sys"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcf0d489f4d9a80ac2b3b35b92fdd8fcf68d33bb67f947afe5cd36e482de576"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
+ "nix 0.29.0",
 ]
 
 [[package]]
@@ -2445,18 +2379,19 @@ dependencies = [
 
 [[package]]
 name = "handy-keys"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c1bb519fbead4e7344bf0fe32718c4cea30fc05e03fc65c242df064f515b03"
+checksum = "88d0d9b8fc275b2472698d55d2f27739efd7b8f0e257e923c1c18a6e8a878d7b"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "evdev",
+ "libc",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
- "rdev 0.5.3",
  "serde",
  "thiserror 2.0.18",
  "windows 0.58.0",
@@ -2704,7 +2639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "log",
@@ -2908,17 +2843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
-]
-
-[[package]]
-name = "inotify"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dd0a94b393c730779ccfd2a872b67b1eb67be3fc33082e733bdb38b5fde4d4"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
 ]
 
 [[package]]
@@ -3281,7 +3205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf7710fbff50c24124331760978fb9086d6de6288dcdb38b25a97f8b1bdebbb"
 dependencies = [
  "core-foundation 0.9.4",
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
 ]
 
 [[package]]
@@ -3530,6 +3454,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -4058,7 +3994,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "once_cell",
- "rdev 0.5.0-2",
+ "rdev",
  "regex",
  "reqwest 0.12.28",
  "rodio",
@@ -4193,7 +4129,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -4863,14 +4799,14 @@ name = "rdev"
 version = "0.5.0-2"
 source = "git+https://github.com/rustdesk-org/rdev#a90dbe1172f8832f54c97c62e823c5a34af5fdfe"
 dependencies = [
- "cocoa 0.24.1",
+ "cocoa",
  "core-foundation 0.9.4",
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "core-graphics 0.22.3",
  "dispatch",
  "enum-map",
  "epoll",
- "inotify 0.10.2",
+ "inotify",
  "lazy_static",
  "libc",
  "log",
@@ -4878,25 +4814,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "widestring",
- "winapi",
- "x11",
-]
-
-[[package]]
-name = "rdev"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00552ca2dc2f93b84cd7b5581de49549411e4e41d89e1c691bcb93dc4be360c3"
-dependencies = [
- "cocoa 0.22.0",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
- "core-graphics 0.19.2",
- "epoll",
- "evdev-rs",
- "inotify 0.8.3",
- "lazy_static",
- "libc",
  "winapi",
  "x11",
 ]
@@ -5316,7 +5233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
@@ -5448,7 +5365,7 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "libc",
  "security-framework-sys",
 ]
@@ -5461,7 +5378,7 @@ checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "libc",
  "security-framework-sys",
 ]
@@ -5472,7 +5389,7 @@ version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -6154,7 +6071,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
- "core-foundation-sys 0.8.7",
+ "core-foundation-sys",
  "libc",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -85,7 +85,7 @@ sha2 = "0.10"
 # Canary, Cohere). Per-platform backend features are added in the target tables.
 transcribe-rs = { version = "0.3.8", features = ["onnx"] }
 transcribe-cpp = { version = "0.1.0", default-features = false }
-handy-keys = "0.2.4"
+handy-keys = "0.3.0"
 ferrous-opencc = "0.2.3"
 clap = { version = "4", features = ["derive"] }
 specta = "=2.0.0-rc.22"


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

<!-- TODO (human, in your own words): 2-3 sentences on the mouse-side-button PTT issue
and why suppressing bound mouse buttons matters. Please fill in — YOUR thinking. -->

_TODO: to be written by the maintainer (Avijit)._

## Related Issues

Fixes #12

## Testing

**Root cause (verified in dependency source, not OpenFlow code):** OpenFlow's HandyKeys
backend registers hotkeys via `HotkeyManager::new_with_blocking()`, so bindings enter the
crate's blocking set. In `handy-keys` **0.2.4**, the Windows **keyboard** hook consults
that set and swallows matched hotkeys (`LRESULT(1)`), but the **mouse** hook always calls
`CallNextHookEx` — the code comments "Always pass mouse events through (no blocking for
mouse)". So a mouse-side-button (MouseX1/X2) push-to-talk binding triggers OpenFlow but
the click ALSO propagates to the focused app (browser Back/Forward, focus/caret
disturbance) — exactly the behavior reported in #12, which the reporter worked around
with an external interceptor re-emitting F10.

**Fix:** upgrade `handy-keys` 0.2.4 → **0.3.0**. Upstream fixed precisely this: in
0.3.0's Windows `mouse_hook_proc`, matched middle/X-button events run
`should_block_hotkey(&ctx.blocking_hotkeys, ctx.current_modifiers, Some(key))` and are
swallowed with `LRESULT(1)` (verified present in the downloaded 0.3.0 sources; the
0.2.4 unconditional pass-through is gone).

**Compatibility audit:** every symbol OpenFlow uses is signature-identical between the
versions (`HotkeyManager` construct/register/unregister/try_recv, `HotkeyEvent`,
`KeyEvent` + `as_hotkey()`, `Hotkey` FromStr/`to_handy_string()`, `Modifiers`). **Zero
Rust source changes** — the diff is Cargo.toml + Cargo.lock. No specta-exported type
changed → no bindings.ts regeneration.

**Verification:**
- `cargo test`: 198 passed / 0 failed. `cargo build` clean. `bunx tsc --noEmit` clean.
- Live keyboard regression (macOS, Intel): app starts with `keyboard_implementation=
  handy_keys` and no Tauri fallback (0.3.0 registration path works); a dictation driven
  via `--toggle-transcription` transcribed the spoken text exactly on the upgraded crate.
- **Windows behavior cannot be exercised on this machine (no Windows hardware).**
  Evidence: upstream fix verified present in the shipped 0.3.0 source + Windows CI
  compiling green. @stepupgaming — once this lands in a release, could you confirm the
  side-button no longer leaks through (your F10 interceptor should become unnecessary)?

**Behavioral notes for the reviewer (0.3.0 changes beyond the fix):**
- macOS **known limitation**: mouse-button hotkeys are detected but still NOT swallowed
  on macOS in 0.3.0 (OtherMouseDown/Up never set should_block) — the fix in this PR is
  Windows-specific because that's where upstream implemented blocking.
- Linux backend rewritten rdev → evdev/uinput: blocking now works on Wayland/X11 but
  requires `/dev/input` read + `/dev/uinput` write permissions (packaging note).
- Additive new `Key` variants (media keys, F21–F24, macOS Dictation key) and a
  modifier-only hotkey release-timing correctness fix.

## Screenshots/Videos (if applicable)

N/A (dependency bump; behavior evidence quoted above).

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Fable orchestrator; Opus sub-agent for the upgrade + audit).
- How extensively: root-cause analysis in the dependency source, the version bump, the
  API-compatibility audit, and the regression verification were AI-performed. "Human
  Written Description" pending.
