### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openflow-app",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "homepage": "https://openflow.computer",
   "repository": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "openflow"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openflow"
-version = "0.12.0"
+version = "0.12.1"
 description = "OpenFlow"
 authors = ["cjpais", "OpenFlow"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenFlow",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "identifier": "knotie.ai.openflow",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

<!-- Version-bump chore for the 0.12.1 patch release; maintainer may add a note. -->

_Chore: version bump 0.12.0 → 0.12.1 for the patch release carrying the #12 fix (PR #14)._

## Related Issues

Follow-up to #14 (fix for #12).

## Testing

Version strings bumped in the four standard locations (package.json, src-tauri/Cargo.toml,
src-tauri/tauri.conf.json, src-tauri/Cargo.lock) — no code changes. CI validates the build.

Post-merge live verification of the underlying fix on macOS (Intel): a `mousex1` binding
was accepted (`changeBinding("transcribe","mousex1")` → success), a synthesized side-button
press (CGEvent, button 3) started recording, and the spoken sentence transcribed exactly —
evidence in `verification/issue-12/proof-log.txt`. Windows suppression behavior awaits
confirmation by the #12 reporter on a released build (no Windows hardware locally).

## Screenshots/Videos (if applicable)

N/A (version bump).

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code.
- How extensively: scripted version bump + this PR.
