### PR TITLE
feat(service): additive "Connect to my service" desktop integration

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod backends;
 pub mod history;
 pub mod meetings;
 pub mod models;
+pub mod service;
 pub mod transcription;
 
 use crate::settings::{get_settings, write_settings, AppSettings, LogLevel};

--- a/src-tauri/src/commands/service.rs
+++ b/src-tauri/src/commands/service.rs
@@ -1,0 +1,366 @@
+//! OpenFlow Service — pairing / status / connection-test Tauri commands.
+//!
+//! Additive & dormant-by-default: none of this runs until the user pairs a
+//! self-hosted service. The device token lives in the OS keyring (never the
+//! settings store); the URL + opt-in flags live in settings. See the frozen
+//! contract DESIGN-openflow-service.md §5 (API) and §8 (desktop integration).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use tauri::{AppHandle, Manager};
+
+use crate::managers::service_sync::{ServiceSyncManager, KEYRING_ACCOUNT, KEYRING_SCOPE};
+use crate::settings::{get_settings, write_settings};
+
+/// Body POSTed to `/v1/pair`. Pure struct so its construction is unit-testable.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct PairRequest {
+    pub setup_token: String,
+    pub device_name: String,
+    pub platform: String,
+    pub app_version: String,
+}
+
+/// Construct the pairing request body from the device's own identity. Kept as a
+/// free function (no I/O) so a test can assert the exact wire shape.
+pub fn build_pair_request(
+    setup_token: &str,
+    device_name: &str,
+    platform: &str,
+    app_version: &str,
+) -> PairRequest {
+    PairRequest {
+        setup_token: setup_token.trim().to_string(),
+        device_name: device_name.to_string(),
+        platform: platform.to_string(),
+        app_version: app_version.to_string(),
+    }
+}
+
+/// `201` response from `/v1/pair`.
+#[derive(Deserialize, Debug)]
+struct PairResponse {
+    device_id: String,
+    device_token: String,
+}
+
+/// Returned to the UI after a successful pairing.
+#[derive(Serialize, Debug, Clone, Type)]
+pub struct PairedDeviceInfo {
+    pub device_id: String,
+    pub device_name: String,
+    pub url: String,
+}
+
+/// Status snapshot for the settings UI.
+#[derive(Serialize, Debug, Clone, Type)]
+pub struct ServiceStatus {
+    /// A URL is configured (feature is at least half-set-up).
+    pub configured: bool,
+    /// A device is paired and the integration is active.
+    pub enabled: bool,
+    pub url: String,
+    pub sync_transcripts: bool,
+    pub sync_usage: bool,
+    pub paired_device_name: Option<String>,
+    /// Unix seconds of the last successful push, if any.
+    pub last_sync_at: Option<i64>,
+    /// History rows not yet synced (informational).
+    pub pending_count: Option<i64>,
+}
+
+/// `/v1/info` response.
+#[derive(Deserialize, Debug)]
+struct InfoResponse {
+    version: String,
+    #[serde(default)]
+    edition: String,
+    #[serde(default)]
+    modules: InfoModules,
+    #[serde(default)]
+    #[allow(dead_code)]
+    server_time: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct InfoModules {
+    #[serde(default)]
+    stt: bool,
+    #[serde(default)]
+    llm: bool,
+    #[serde(default)]
+    memory: bool,
+}
+
+/// Typed result of a connection test / info fetch.
+#[derive(Serialize, Debug, Clone, Type)]
+pub struct ServiceInfo {
+    pub version: String,
+    pub edition: String,
+    pub module_stt: bool,
+    pub module_llm: bool,
+    pub module_memory: bool,
+}
+
+fn normalize(base: &str) -> String {
+    base.trim().trim_end_matches('/').to_string()
+}
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap_or_default()
+}
+
+/// Map a non-success pairing status to a friendly, user-facing message.
+fn pair_error_for_status(status: reqwest::StatusCode) -> String {
+    match status.as_u16() {
+        401 | 403 => "Pairing rejected: the setup token is wrong or expired.".to_string(),
+        404 => "No OpenFlow Service found at that URL. Check the address.".to_string(),
+        409 => "This device is already paired with the service.".to_string(),
+        429 => "Too many pairing attempts. Wait a minute and try again.".to_string(),
+        500..=599 => "The service had an internal error. Try again shortly.".to_string(),
+        _ => format!("Pairing failed (HTTP {}).", status.as_u16()),
+    }
+}
+
+/// Pair this device with a self-hosted OpenFlow Service.
+///
+/// On `201`: store the returned `device_token` in the OS keyring, persist the URL,
+/// set `service_enabled = true`, record the device identity, and start the sync
+/// worker. On any error: friendly message, nothing persisted.
+#[tauri::command]
+#[specta::specta]
+pub async fn pair_service(
+    app: AppHandle,
+    url: String,
+    setup_token: String,
+) -> Result<PairedDeviceInfo, String> {
+    let base = normalize(&url);
+    if base.is_empty() {
+        return Err("Enter the service URL.".to_string());
+    }
+    if setup_token.trim().is_empty() {
+        return Err("Enter the setup token from your service.".to_string());
+    }
+
+    let device_name = tauri_plugin_os::hostname();
+    let platform = tauri_plugin_os::platform().to_string();
+    let app_version = app.package_info().version.to_string();
+    let body = build_pair_request(&setup_token, &device_name, &platform, &app_version);
+
+    let resp = http_client()
+        .post(format!("{base}/v1/pair"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Could not reach the service: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(pair_error_for_status(status));
+    }
+
+    let parsed: PairResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("The service returned an unexpected response: {e}"))?;
+
+    // Token → keyring ONLY (never the settings store).
+    crate::keychain::set_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT, &parsed.device_token)
+        .map_err(|e| format!("Could not store the device token securely: {e}"))?;
+
+    // Persist URL + enable; the token is intentionally absent from settings.
+    let mut settings = get_settings(&app);
+    settings.service_url = base.clone();
+    settings.service_enabled = true;
+    write_settings(&app, settings);
+
+    // Record identity + kick the worker (idempotent).
+    let manager = app.state::<Arc<ServiceSyncManager>>();
+    manager.record_pairing(&parsed.device_id, &device_name);
+    manager.ensure_started();
+
+    Ok(PairedDeviceInfo {
+        device_id: parsed.device_id,
+        device_name,
+        url: base,
+    })
+}
+
+/// Unpair: best-effort revoke on the server, then remove the local token and
+/// disable the feature. Always succeeds locally even if the server is unreachable.
+#[tauri::command]
+#[specta::specta]
+pub async fn unpair_service(app: AppHandle) -> Result<(), String> {
+    let settings = get_settings(&app);
+    let base = normalize(&settings.service_url);
+    let token = crate::keychain::get_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT).unwrap_or_default();
+    let device_id = {
+        let manager = app.state::<Arc<ServiceSyncManager>>();
+        manager.snapshot().device_id
+    };
+
+    // Best-effort server-side revoke (DELETE /v1/devices/{self}). Ignore failures.
+    if !base.is_empty() && !token.is_empty() {
+        if let Some(id) = device_id {
+            let _ = http_client()
+                .delete(format!("{base}/v1/devices/{id}"))
+                .bearer_auth(&token)
+                .send()
+                .await;
+        }
+    }
+
+    // Stop the worker, forget the token, clear local state, disable the feature.
+    {
+        let manager = app.state::<Arc<ServiceSyncManager>>();
+        manager.stop();
+        manager.clear_pairing();
+    }
+    let _ = crate::keychain::delete_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT);
+
+    let mut settings = get_settings(&app);
+    settings.service_enabled = false;
+    settings.service_sync_transcripts = false;
+    settings.service_sync_usage = false;
+    // Keep the URL so the field stays pre-filled for a quick re-pair.
+    write_settings(&app, settings);
+
+    Ok(())
+}
+
+/// Current status for the settings UI.
+#[tauri::command]
+#[specta::specta]
+pub fn service_status(app: AppHandle) -> Result<ServiceStatus, String> {
+    let settings = get_settings(&app);
+    let manager = app.state::<Arc<ServiceSyncManager>>();
+    let snap = manager.snapshot();
+    let configured = !settings.service_url.trim().is_empty();
+
+    Ok(ServiceStatus {
+        configured,
+        enabled: settings.service_enabled,
+        url: settings.service_url.clone(),
+        sync_transcripts: settings.service_sync_transcripts,
+        sync_usage: settings.service_sync_usage,
+        paired_device_name: snap.device_name,
+        last_sync_at: snap.last_sync_at,
+        pending_count: if settings.service_enabled {
+            Some(manager.pending_count())
+        } else {
+            None
+        },
+    })
+}
+
+/// Test the connection with the stored token: `GET /v1/info`.
+#[tauri::command]
+#[specta::specta]
+pub async fn test_service_connection(app: AppHandle) -> Result<ServiceInfo, String> {
+    let settings = get_settings(&app);
+    let base = normalize(&settings.service_url);
+    if base.is_empty() {
+        return Err("No service URL configured.".to_string());
+    }
+    let token = crate::keychain::get_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT).unwrap_or_default();
+    if token.is_empty() {
+        return Err("This device is not paired yet.".to_string());
+    }
+
+    let resp = http_client()
+        .get(format!("{base}/v1/info"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|e| format!("Could not reach the service: {e}"))?;
+
+    let status = resp.status();
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        return Err("The service rejected this device's token. Try re-pairing.".to_string());
+    }
+    if !status.is_success() {
+        return Err(format!("The service returned HTTP {}.", status.as_u16()));
+    }
+
+    let info: InfoResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Unexpected response from the service: {e}"))?;
+
+    Ok(ServiceInfo {
+        version: info.version,
+        edition: if info.edition.is_empty() {
+            "community".to_string()
+        } else {
+            info.edition
+        },
+        module_stt: info.modules.stt,
+        module_llm: info.modules.llm,
+        module_memory: info.modules.memory,
+    })
+}
+
+/// Toggle transcript sync (privacy-critical opt-in). Also nudges the worker so a
+/// freshly-enabled sync starts promptly.
+#[tauri::command]
+#[specta::specta]
+pub fn set_service_sync_transcripts(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = get_settings(&app);
+    settings.service_sync_transcripts = enabled;
+    write_settings(&app, settings);
+    app.state::<Arc<ServiceSyncManager>>().ensure_started();
+    Ok(())
+}
+
+/// Toggle usage-event sync (counts/durations only — never text).
+#[tauri::command]
+#[specta::specta]
+pub fn set_service_sync_usage(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = get_settings(&app);
+    settings.service_sync_usage = enabled;
+    write_settings(&app, settings);
+    app.state::<Arc<ServiceSyncManager>>().ensure_started();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pair_request_body_is_constructed_verbatim() {
+        let req = build_pair_request("  tok-123  ", "My-Mac", "macos", "0.14.0");
+        // Setup token is trimmed; identity fields pass through untouched.
+        assert_eq!(req.setup_token, "tok-123");
+        assert_eq!(req.device_name, "My-Mac");
+        assert_eq!(req.platform, "macos");
+        assert_eq!(req.app_version, "0.14.0");
+    }
+
+    #[test]
+    fn pair_request_serializes_to_the_contract_shape() {
+        let req = build_pair_request("tok", "host", "windows", "1.2.3");
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["setup_token"], "tok");
+        assert_eq!(json["device_name"], "host");
+        assert_eq!(json["platform"], "windows");
+        assert_eq!(json["app_version"], "1.2.3");
+        // Exactly the four contract fields, nothing extra.
+        assert_eq!(json.as_object().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn pair_error_messages_map_common_statuses() {
+        use reqwest::StatusCode;
+        assert!(pair_error_for_status(StatusCode::UNAUTHORIZED).contains("setup token"));
+        assert!(pair_error_for_status(StatusCode::NOT_FOUND).contains("No OpenFlow Service"));
+        assert!(pair_error_for_status(StatusCode::TOO_MANY_REQUESTS).contains("Too many"));
+        assert!(pair_error_for_status(StatusCode::CONFLICT).contains("already paired"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -200,6 +200,12 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     // now), and is a sibling of the TranscriptionCoordinator — never a client.
     let meeting_manager = Arc::new(managers::meeting::MeetingManager::new(app_handle));
 
+    // OpenFlow Service sync worker: a dormant-by-default sibling that pushes NEW
+    // history rows (READ-ONLY) + usage events to a user-paired self-hosted service.
+    // Started below ONLY when the feature is configured; never touches dictation.
+    let service_sync_manager =
+        Arc::new(managers::service_sync::ServiceSyncManager::new(app_handle));
+
     // Add managers to Tauri's managed state
     app_handle.manage(recording_manager.clone());
     app_handle.manage(model_manager.clone());
@@ -209,6 +215,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     app_handle.manage(wake_word_manager.clone());
     app_handle.manage(agent_run_manager.clone());
     app_handle.manage(meeting_manager.clone());
+    app_handle.manage(service_sync_manager.clone());
 
     // Note: Shortcuts are NOT initialized here.
     // The frontend is responsible for calling the `initialize_shortcuts` command
@@ -348,6 +355,11 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     if settings::get_settings(app_handle).hands_free_enabled {
         wake_word_manager.start();
     }
+
+    // Start the OpenFlow Service sync worker ONLY when the user has paired and the
+    // feature is enabled (byte-for-byte no-op otherwise). `ensure_started` itself
+    // re-checks the gate, so this is safe and idempotent.
+    service_sync_manager.ensure_started();
 
     // Start the meeting detector. Its loop reads settings live and self-suppresses
     // while our own recorder/monitor is active or a meeting capture is running, so
@@ -744,6 +756,12 @@ pub fn run(cli_args: CliArgs) {
             commands::meetings::set_meetings_diarization_provisional,
             commands::meetings::get_diarization_models_status,
             commands::meetings::download_diarization_models,
+            commands::service::pair_service,
+            commands::service::unpair_service,
+            commands::service::service_status,
+            commands::service::test_service_connection,
+            commands::service::set_service_sync_transcripts,
+            commands::service::set_service_sync_usage,
             helpers::clamshell::is_laptop,
         ])
         .events(collect_events![

--- a/src-tauri/src/managers/mod.rs
+++ b/src-tauri/src/managers/mod.rs
@@ -6,5 +6,6 @@ pub mod history;
 pub mod meeting;
 pub mod model;
 pub mod model_capabilities;
+pub mod service_sync;
 pub mod transcription;
 pub mod wake_word;

--- a/src-tauri/src/managers/service_sync.rs
+++ b/src-tauri/src/managers/service_sync.rs
@@ -1,0 +1,721 @@
+//! OpenFlow Service — dictation transcript + usage sync worker.
+//!
+//! This is a *sibling* pipeline, never part of the core dictation path (hotkey →
+//! capture → STT → cleanup → inject). It runs a single background tokio task that,
+//! every 30s, reads NEW rows from the existing history SQLite (`history.db`,
+//! READ-ONLY — the schema is never modified) and pushes them to a user-paired,
+//! self-hosted OpenFlow Service per the frozen contract (DESIGN-openflow-service.md
+//! §5/§8). It is fully dormant unless the user has paired and opted in:
+//!
+//!   * The task is only ever started when `service_enabled && !service_url.empty`.
+//!   * Transcript TEXT is pushed ONLY when `service_sync_transcripts` is true — the
+//!     hard privacy rule. Usage events (`service_sync_usage`) carry counts/durations
+//!     only, never text.
+//!   * Its cursor + device identity live in a SEPARATE `service_sync.db`, so the
+//!     history database and the dictation loop are untouched.
+//!
+//! The HTTP calls sit behind the [`ServiceTransport`] trait so the batching /
+//! backoff / payload logic is unit-testable with no network.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::DateTime;
+use log::{debug, warn};
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+use tauri::AppHandle;
+
+/// Keyring scope/account the device token is stored under. Mirrors the existing
+/// `keychain` pattern used for provider API keys — the token NEVER touches the
+/// settings store on disk.
+pub const KEYRING_SCOPE: &str = "service";
+pub const KEYRING_ACCOUNT: &str = "device_token";
+
+/// Max items per push batch (contract §8: batches ≤ 50).
+pub const MAX_BATCH: usize = 50;
+
+/// Backoff floor / ceiling on repeated push failure (contract §8: 30s → 5min cap).
+pub const BACKOFF_MIN: Duration = Duration::from_secs(30);
+pub const BACKOFF_MAX: Duration = Duration::from_secs(300);
+
+/// Normal poll cadence between sync passes.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Pure data + logic (unit-tested; no I/O)
+// ---------------------------------------------------------------------------
+
+/// A minimal, read-only view of one `transcription_history` row that the sync
+/// worker cares about. Deliberately decoupled from `HistoryEntry` so this module
+/// never depends on the history manager's write path.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SyncRow {
+    /// The history SQLite rowid. Stable and monotonic → used verbatim as the
+    /// idempotency `client_id`, so re-sending a row is a server-side no-op.
+    pub rowid: i64,
+    /// Unix seconds (the history `timestamp` column).
+    pub created_at: i64,
+    /// The transcript text (STT output).
+    pub text: String,
+    /// Duration in milliseconds, if the source row carries one. The
+    /// `transcription_history` table does not have a duration column today, so
+    /// this is `None` in practice — the plumbing honors the contract's
+    /// `value=duration_ms` for the day a duration becomes available.
+    pub duration_ms: Option<i64>,
+}
+
+/// Stable idempotency key for a row: the history rowid as a string. Identical for
+/// the transcript push and the paired usage event, so the service can dedupe both
+/// on `(device_id, client_id)`.
+pub fn client_id_for(rowid: i64) -> String {
+    rowid.to_string()
+}
+
+/// Split rows into ordered batches of at most [`MAX_BATCH`], preserving order.
+pub fn into_batches(rows: &[SyncRow]) -> Vec<Vec<SyncRow>> {
+    rows.chunks(MAX_BATCH).map(|c| c.to_vec()).collect()
+}
+
+/// Next backoff after a failure: double the current delay, clamped to
+/// [`BACKOFF_MIN`, `BACKOFF_MAX`]. A zero/sub-floor input starts at the floor.
+pub fn next_backoff(current: Duration) -> Duration {
+    if current < BACKOFF_MIN {
+        return BACKOFF_MIN;
+    }
+    let doubled = current.saturating_mul(2);
+    if doubled > BACKOFF_MAX {
+        BACKOFF_MAX
+    } else {
+        doubled
+    }
+}
+
+/// RFC3339 UTC rendering of a unix-seconds timestamp (contract: all timestamps
+/// RFC3339 UTC). Falls back to the epoch for an out-of-range value rather than
+/// ever panicking on the sync path.
+pub fn to_rfc3339(unix_secs: i64) -> String {
+    DateTime::from_timestamp(unix_secs, 0)
+        .unwrap_or_else(|| DateTime::from_timestamp(0, 0).expect("epoch is valid"))
+        .to_rfc3339()
+}
+
+// ---- wire payloads (contract §5) ----
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct TranscriptItem {
+    pub client_id: String,
+    pub created_at: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<i64>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct TranscriptsBody {
+    pub items: Vec<TranscriptItem>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct UsageItem {
+    pub client_id: String,
+    pub kind: String,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<i64>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct UsageBody {
+    pub items: Vec<UsageItem>,
+}
+
+/// Build the `/v1/transcripts` body for a batch (carries TEXT — only ever called
+/// when `service_sync_transcripts` is on).
+pub fn build_transcripts_body(rows: &[SyncRow]) -> TranscriptsBody {
+    TranscriptsBody {
+        items: rows
+            .iter()
+            .map(|r| TranscriptItem {
+                client_id: client_id_for(r.rowid),
+                created_at: to_rfc3339(r.created_at),
+                text: r.text.clone(),
+                duration_ms: r.duration_ms,
+            })
+            .collect(),
+    }
+}
+
+/// Build the `/v1/usage` body for a batch. Contains NO transcript text — only the
+/// stable client_id, kind, timestamp and (optional) duration value.
+pub fn build_usage_body(rows: &[SyncRow]) -> UsageBody {
+    UsageBody {
+        items: rows
+            .iter()
+            .map(|r| UsageItem {
+                client_id: client_id_for(r.rowid),
+                kind: "dictation".to_string(),
+                created_at: to_rfc3339(r.created_at),
+                value: r.duration_ms,
+            })
+            .collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP transport abstraction
+// ---------------------------------------------------------------------------
+
+/// The two write calls the worker makes, behind a trait so logic can be tested
+/// without a network. Owned args keep the returned futures `'static` + `Send`.
+pub trait ServiceTransport: Send + Sync + 'static {
+    fn post_transcripts(
+        &self,
+        base_url: String,
+        token: String,
+        body: TranscriptsBody,
+    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
+
+    fn post_usage(
+        &self,
+        base_url: String,
+        token: String,
+        body: UsageBody,
+    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
+}
+
+/// Production transport backed by `reqwest`. Normalizes the base URL and maps
+/// non-2xx / transport errors to a short string (logged, then retried).
+pub struct HttpTransport {
+    client: reqwest::Client,
+}
+
+impl Default for HttpTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpTransport {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        Self { client }
+    }
+
+    async fn post_json<B: Serialize>(
+        &self,
+        base_url: &str,
+        token: &str,
+        path: &str,
+        body: &B,
+    ) -> Result<(), String> {
+        let url = format!("{}{}", normalize_base_url(base_url), path);
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| format!("request failed: {e}"))?;
+        let status = resp.status();
+        if status.is_success() {
+            Ok(())
+        } else {
+            let text = resp.text().await.unwrap_or_default();
+            Err(format!(
+                "HTTP {status}: {}",
+                text.chars().take(200).collect::<String>()
+            ))
+        }
+    }
+}
+
+impl ServiceTransport for HttpTransport {
+    async fn post_transcripts(
+        &self,
+        base_url: String,
+        token: String,
+        body: TranscriptsBody,
+    ) -> Result<(), String> {
+        self.post_json(&base_url, &token, "/v1/transcripts", &body)
+            .await
+    }
+
+    async fn post_usage(
+        &self,
+        base_url: String,
+        token: String,
+        body: UsageBody,
+    ) -> Result<(), String> {
+        self.post_json(&base_url, &token, "/v1/usage", &body).await
+    }
+}
+
+/// Strip a trailing slash so `format!("{base}/v1/...")` never doubles up.
+pub fn normalize_base_url(base: &str) -> String {
+    base.trim().trim_end_matches('/').to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Sync-state persistence (its OWN db — history.db is never written)
+// ---------------------------------------------------------------------------
+
+fn open_state_db(path: &PathBuf) -> rusqlite::Result<Connection> {
+    let conn = Connection::open(path)?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sync_state (
+            key   TEXT PRIMARY KEY,
+            value TEXT
+        )",
+        [],
+    )?;
+    Ok(conn)
+}
+
+fn state_get(conn: &Connection, key: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM sync_state WHERE key = ?1",
+        [key],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
+fn state_set(conn: &Connection, key: &str, value: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO sync_state (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        [key, value],
+    )?;
+    Ok(())
+}
+
+const KEY_CURSOR: &str = "cursor";
+const KEY_LAST_SYNC_AT: &str = "last_sync_at";
+const KEY_DEVICE_ID: &str = "device_id";
+const KEY_DEVICE_NAME: &str = "device_name";
+
+/// A snapshot of sync progress for the status command.
+#[derive(Clone, Debug, Default)]
+pub struct SyncStateSnapshot {
+    pub device_id: Option<String>,
+    pub device_name: Option<String>,
+    pub last_sync_at: Option<i64>,
+    pub cursor: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+/// Owns the sync-state db path and the running flag. Managed in Tauri state; the
+/// worker task is (re)started idempotently via [`Self::ensure_started`].
+pub struct ServiceSyncManager {
+    app: AppHandle,
+    state_db_path: PathBuf,
+    history_db_path: PathBuf,
+    running: Arc<AtomicBool>,
+}
+
+impl ServiceSyncManager {
+    pub fn new(app: &AppHandle) -> Self {
+        // Best-effort resolve of the data dir; if it fails we fall back to a
+        // relative path (the worker will simply log and never start syncing).
+        let data_dir = crate::portable::app_data_dir(app).unwrap_or_else(|_| PathBuf::from("."));
+        Self {
+            app: app.clone(),
+            state_db_path: data_dir.join("service_sync.db"),
+            history_db_path: data_dir.join("history.db"),
+            running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Persist the device identity after a successful pairing (used by the status
+    /// UI). The token itself goes to the keyring, never here.
+    pub fn record_pairing(&self, device_id: &str, device_name: &str) {
+        if let Ok(conn) = open_state_db(&self.state_db_path) {
+            let _ = state_set(&conn, KEY_DEVICE_ID, device_id);
+            let _ = state_set(&conn, KEY_DEVICE_NAME, device_name);
+        }
+    }
+
+    /// Forget the paired device identity + cursor on unpair. Leaves the table so a
+    /// later re-pair starts clean.
+    pub fn clear_pairing(&self) {
+        if let Ok(conn) = open_state_db(&self.state_db_path) {
+            let _ = conn.execute("DELETE FROM sync_state", []);
+        }
+    }
+
+    /// Read a snapshot of sync progress (for `service_status`).
+    pub fn snapshot(&self) -> SyncStateSnapshot {
+        let mut snap = SyncStateSnapshot::default();
+        if let Ok(conn) = open_state_db(&self.state_db_path) {
+            snap.device_id = state_get(&conn, KEY_DEVICE_ID);
+            snap.device_name = state_get(&conn, KEY_DEVICE_NAME);
+            snap.last_sync_at = state_get(&conn, KEY_LAST_SYNC_AT).and_then(|v| v.parse().ok());
+            snap.cursor = state_get(&conn, KEY_CURSOR)
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+        }
+        snap
+    }
+
+    /// Count history rows not yet synced (id > cursor). Read-only; returns 0 on
+    /// any error so the status UI degrades gracefully.
+    pub fn pending_count(&self) -> i64 {
+        let cursor = self.snapshot().cursor;
+        read_pending_count(&self.history_db_path, cursor).unwrap_or(0)
+    }
+
+    /// Stop the worker (unpair / disable). The loop observes the flag each pass.
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+    }
+
+    /// Start the worker if it is not already running AND the feature is
+    /// configured. Idempotent — safe to call from setup, after pairing, and on
+    /// settings changes.
+    pub fn ensure_started(&self) {
+        let settings = crate::settings::get_settings(&self.app);
+        if !settings.service_enabled || settings.service_url.trim().is_empty() {
+            return;
+        }
+        // CAS false→true so only one loop ever runs.
+        if self
+            .running
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let app = self.app.clone();
+        let state_db_path = self.state_db_path.clone();
+        let history_db_path = self.history_db_path.clone();
+        let running = self.running.clone();
+        let transport = Arc::new(HttpTransport::new());
+
+        tauri::async_runtime::spawn(async move {
+            run_sync_loop(app, transport, state_db_path, history_db_path, running).await;
+        });
+    }
+}
+
+/// The background loop. Generic over the transport so tests can drive it without a
+/// network (the app only ever instantiates it with [`HttpTransport`]).
+async fn run_sync_loop<T: ServiceTransport>(
+    app: AppHandle,
+    transport: Arc<T>,
+    state_db_path: PathBuf,
+    history_db_path: PathBuf,
+    running: Arc<AtomicBool>,
+) {
+    debug!("service_sync: worker started");
+    let mut backoff: Option<Duration> = None;
+
+    while running.load(Ordering::SeqCst) {
+        let settings = crate::settings::get_settings(&app);
+
+        // Feature turned off underneath us (unpair) → exit cleanly.
+        if !settings.service_enabled || settings.service_url.trim().is_empty() {
+            debug!("service_sync: feature disabled, worker exiting");
+            break;
+        }
+
+        // Nothing to do unless at least one sync type is opted in. Sit idle.
+        let want_transcripts = settings.service_sync_transcripts;
+        let want_usage = settings.service_sync_usage;
+        if !want_transcripts && !want_usage {
+            sleep_interruptible(POLL_INTERVAL, &running).await;
+            continue;
+        }
+
+        let token = match crate::keychain::get_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT) {
+            Some(t) if !t.is_empty() => t,
+            _ => {
+                // Paired flag set but no token (shouldn't happen) — back off.
+                warn!("service_sync: enabled but no device token in keyring");
+                sleep_interruptible(POLL_INTERVAL, &running).await;
+                continue;
+            }
+        };
+
+        match sync_once(
+            transport.as_ref(),
+            &settings.service_url,
+            &token,
+            &state_db_path,
+            &history_db_path,
+            want_transcripts,
+            want_usage,
+        )
+        .await
+        {
+            Ok(pushed) => {
+                if pushed > 0 {
+                    debug!("service_sync: pushed {pushed} row(s)");
+                }
+                backoff = None;
+                sleep_interruptible(POLL_INTERVAL, &running).await;
+            }
+            Err(e) => {
+                let delay = next_backoff(backoff.unwrap_or(Duration::ZERO));
+                backoff = Some(delay);
+                warn!(
+                    "service_sync: push failed ({e}); retrying in {}s",
+                    delay.as_secs()
+                );
+                sleep_interruptible(delay, &running).await;
+            }
+        }
+    }
+
+    running.store(false, Ordering::SeqCst);
+    debug!("service_sync: worker stopped");
+}
+
+/// One sync pass: read rows past the cursor, push in batches, advance the cursor
+/// only on success. Returns the number of rows pushed. Never touches history.db
+/// except to READ.
+async fn sync_once<T: ServiceTransport>(
+    transport: &T,
+    base_url: &str,
+    token: &str,
+    state_db_path: &PathBuf,
+    history_db_path: &PathBuf,
+    want_transcripts: bool,
+    want_usage: bool,
+) -> Result<usize, String> {
+    let cursor = {
+        let conn = open_state_db(state_db_path).map_err(|e| format!("state db: {e}"))?;
+        state_get(&conn, KEY_CURSOR)
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(0)
+    };
+
+    let rows = read_history_since(history_db_path, cursor, 500)
+        .map_err(|e| format!("history read: {e}"))?;
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let mut pushed = 0usize;
+    for batch in into_batches(&rows) {
+        if batch.is_empty() {
+            continue;
+        }
+        // Privacy rule: transcript TEXT is only ever sent when opted in.
+        if want_transcripts {
+            transport
+                .post_transcripts(
+                    base_url.to_string(),
+                    token.to_string(),
+                    build_transcripts_body(&batch),
+                )
+                .await?;
+        }
+        if want_usage {
+            transport
+                .post_usage(
+                    base_url.to_string(),
+                    token.to_string(),
+                    build_usage_body(&batch),
+                )
+                .await?;
+        }
+
+        // Advance the cursor to the last row of this batch and stamp the sync
+        // time. Only reached when the required post(s) above succeeded.
+        let last_rowid = batch.last().map(|r| r.rowid).unwrap_or(cursor);
+        let conn = open_state_db(state_db_path).map_err(|e| format!("state db: {e}"))?;
+        state_set(&conn, KEY_CURSOR, &last_rowid.to_string())
+            .map_err(|e| format!("cursor persist: {e}"))?;
+        state_set(
+            &conn,
+            KEY_LAST_SYNC_AT,
+            &chrono::Utc::now().timestamp().to_string(),
+        )
+        .map_err(|e| format!("last_sync persist: {e}"))?;
+        pushed += batch.len();
+    }
+
+    Ok(pushed)
+}
+
+/// READ-ONLY query of the existing history db for rows past the cursor.
+fn read_history_since(
+    history_db_path: &PathBuf,
+    cursor: i64,
+    limit: i64,
+) -> rusqlite::Result<Vec<SyncRow>> {
+    let conn = Connection::open_with_flags(
+        history_db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let mut stmt = conn.prepare(
+        "SELECT id, timestamp, transcription_text
+         FROM transcription_history
+         WHERE id > ?1
+         ORDER BY id ASC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(rusqlite::params![cursor, limit], |row| {
+            Ok(SyncRow {
+                rowid: row.get(0)?,
+                created_at: row.get(1)?,
+                text: row.get(2)?,
+                duration_ms: None,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// READ-ONLY count of history rows past the cursor (for status pending_count).
+fn read_pending_count(history_db_path: &PathBuf, cursor: i64) -> rusqlite::Result<i64> {
+    let conn = Connection::open_with_flags(
+        history_db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    conn.query_row(
+        "SELECT COUNT(*) FROM transcription_history WHERE id > ?1",
+        [cursor],
+        |row| row.get(0),
+    )
+}
+
+/// Sleep up to `dur`, waking early (in ~1s slices) if `running` is cleared, so an
+/// unpair takes effect promptly rather than after a full poll interval.
+async fn sleep_interruptible(dur: Duration, running: &Arc<AtomicBool>) {
+    let mut remaining = dur;
+    let step = Duration::from_secs(1);
+    while remaining > Duration::ZERO {
+        if !running.load(Ordering::SeqCst) {
+            return;
+        }
+        let this = remaining.min(step);
+        tokio::time::sleep(this).await;
+        remaining = remaining.saturating_sub(this);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(rowid: i64) -> SyncRow {
+        SyncRow {
+            rowid,
+            created_at: 1_600_000_000 + rowid,
+            text: format!("row {rowid}"),
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn batching_splits_into_chunks_of_50() {
+        let rows: Vec<SyncRow> = (1..=125).map(row).collect();
+        let batches = into_batches(&rows);
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[0].len(), 50);
+        assert_eq!(batches[1].len(), 50);
+        assert_eq!(batches[2].len(), 25);
+        // Order is preserved end to end.
+        assert_eq!(batches[0][0].rowid, 1);
+        assert_eq!(batches[2][24].rowid, 125);
+    }
+
+    #[test]
+    fn batching_handles_empty_and_exact_boundary() {
+        assert!(into_batches(&[]).is_empty());
+        let exact: Vec<SyncRow> = (1..=50).map(row).collect();
+        let b = into_batches(&exact);
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].len(), 50);
+        let plus_one: Vec<SyncRow> = (1..=51).map(row).collect();
+        let b2 = into_batches(&plus_one);
+        assert_eq!(b2.len(), 2);
+        assert_eq!(b2[1].len(), 1);
+    }
+
+    #[test]
+    fn client_id_is_the_rowid_and_stable() {
+        assert_eq!(client_id_for(42), "42");
+        // Same row → same client_id every time (idempotency guarantee).
+        assert_eq!(client_id_for(42), client_id_for(42));
+        // The transcript push and the usage push for a row share the client_id.
+        let r = row(7);
+        let t = build_transcripts_body(std::slice::from_ref(&r));
+        let u = build_usage_body(std::slice::from_ref(&r));
+        assert_eq!(t.items[0].client_id, "7");
+        assert_eq!(u.items[0].client_id, "7");
+        assert_eq!(t.items[0].client_id, u.items[0].client_id);
+    }
+
+    #[test]
+    fn backoff_progression_doubles_and_caps() {
+        // Starts at the 30s floor from zero.
+        let d0 = next_backoff(Duration::ZERO);
+        assert_eq!(d0, BACKOFF_MIN);
+        // Doubles: 30 → 60 → 120 → 240 → 300 (cap), then stays at 300.
+        let d1 = next_backoff(d0);
+        assert_eq!(d1, Duration::from_secs(60));
+        let d2 = next_backoff(d1);
+        assert_eq!(d2, Duration::from_secs(120));
+        let d3 = next_backoff(d2);
+        assert_eq!(d3, Duration::from_secs(240));
+        let d4 = next_backoff(d3);
+        assert_eq!(d4, BACKOFF_MAX); // capped at 300
+        let d5 = next_backoff(d4);
+        assert_eq!(d5, BACKOFF_MAX); // stays capped
+    }
+
+    #[test]
+    fn usage_body_never_contains_text() {
+        let rows: Vec<SyncRow> = (1..=3).map(row).collect();
+        let usage = build_usage_body(&rows);
+        let json = serde_json::to_string(&usage).unwrap();
+        // The transcript text ("row 1" etc.) must NOT appear in a usage payload.
+        assert!(!json.contains("row 1"));
+        assert!(json.contains("\"kind\":\"dictation\""));
+        assert_eq!(usage.items.len(), 3);
+    }
+
+    #[test]
+    fn transcript_body_carries_text_and_rfc3339_timestamp() {
+        let r = SyncRow {
+            rowid: 5,
+            created_at: 1_600_000_000,
+            text: "hello world".to_string(),
+            duration_ms: Some(4200),
+        };
+        let body = build_transcripts_body(std::slice::from_ref(&r));
+        assert_eq!(body.items[0].text, "hello world");
+        assert_eq!(body.items[0].client_id, "5");
+        assert_eq!(body.items[0].duration_ms, Some(4200));
+        // RFC3339 UTC (2020-09-13T12:26:40+00:00).
+        assert!(body.items[0].created_at.starts_with("2020-09-13T12:26:40"));
+    }
+
+    #[test]
+    fn duration_is_omitted_from_json_when_absent() {
+        let body = build_transcripts_body(std::slice::from_ref(&row(1)));
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(!json.contains("duration_ms"));
+    }
+
+    #[test]
+    fn normalize_base_url_strips_trailing_slash() {
+        assert_eq!(normalize_base_url("https://x.io/"), "https://x.io");
+        assert_eq!(normalize_base_url("https://x.io"), "https://x.io");
+        assert_eq!(normalize_base_url("  https://x.io/  "), "https://x.io");
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -903,6 +903,30 @@ pub struct AppSettings {
     /// (DESIGN-meetings.md §5.4 auto-degrade). Users on fast machines can opt in.
     #[serde(default)]
     pub meetings_diarization_provisional: bool,
+
+    // ---- OpenFlow Service ("Connect to my service") ----
+    /// Base URL of the paired self-hosted OpenFlow Service (e.g.
+    /// `https://openflow.example.com`). Empty = feature fully dormant: no sync
+    /// worker is ever started and nothing leaves the machine. The device token
+    /// itself is NEVER stored here — it lives in the OS keyring (scope
+    /// `"service"`, account `"device_token"`); this struct only holds the URL and
+    /// opt-in flags. All four fields are `#[serde(default)]` so an old settings
+    /// store (with none of these keys) deserializes byte-for-byte as before.
+    #[serde(default)]
+    pub service_url: String,
+    /// Whether a device is paired and the integration is active. Set true only on
+    /// a successful `pair_service`; cleared by `unpair_service`. When false the
+    /// sync worker does nothing even if a URL is present.
+    #[serde(default)]
+    pub service_enabled: bool,
+    /// Opt-in: push dictation transcript TEXT to the service. Default OFF. When
+    /// false, transcript text NEVER leaves the machine (privacy rule).
+    #[serde(default)]
+    pub service_sync_transcripts: bool,
+    /// Opt-in: push usage events (dictation counts/durations, NO text) to the
+    /// service. Default OFF. Independent of `service_sync_transcripts`.
+    #[serde(default)]
+    pub service_sync_usage: bool,
 }
 
 fn default_meeting_app_allowlist() -> Vec<String> {
@@ -1486,6 +1510,12 @@ pub fn get_default_settings() -> AppSettings {
         meeting_app_allowlist: default_meeting_app_allowlist(),
         meetings_diarization: true,
         meetings_diarization_provisional: false,
+
+        // OpenFlow Service — dormant by default (empty URL, all opt-ins off).
+        service_url: String::new(),
+        service_enabled: false,
+        service_sync_transcripts: false,
+        service_sync_usage: false,
     }
 }
 
@@ -1821,6 +1851,33 @@ mod tests {
         assert_eq!(fresh.default_ai_mode_id, None);
         assert!(!fresh.basic_filler_filter);
         assert!(fresh.hotkey_overlay_enabled);
+    }
+
+    #[test]
+    fn legacy_store_without_service_fields_defaults_them_off() {
+        // Non-breaking proof for the OpenFlow Service feature: a settings store
+        // persisted BEFORE any `service_*` key existed must deserialize with the
+        // integration fully dormant — empty URL, everything off — so an upgrading
+        // user's config is byte-for-byte unaffected and nothing is ever synced
+        // until they explicitly pair and opt in.
+        let raw = serde_json::json!({
+            "bindings": {},
+            "push_to_talk": true,
+            "audio_feedback": false
+        });
+        let settings: AppSettings =
+            serde_json::from_value(raw).expect("pre-service store should deserialize");
+        assert_eq!(settings.service_url, "");
+        assert!(!settings.service_enabled);
+        assert!(!settings.service_sync_transcripts);
+        assert!(!settings.service_sync_usage);
+
+        // Fresh-install defaults match: the feature is dormant out of the box.
+        let fresh = get_default_settings();
+        assert_eq!(fresh.service_url, "");
+        assert!(!fresh.service_enabled);
+        assert!(!fresh.service_sync_transcripts);
+        assert!(!fresh.service_sync_usage);
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1027,13 +1027,16 @@ async setHotkeyOverlayEnabled(enabled: boolean) : Promise<Result<null, string>> 
 },
 /**
  * Resolve a CLI agent's binary path (`which`-style). Searches, in order: the
- * process PATH, then an explicit baseline of tool dirs (Homebrew on either
- * arch, `~/.local/bin`, bun/cargo/volta/deno, every nvm node version) that a
- * GUI-launched app's stripped launchd PATH omits — this is why detection found
- * nothing on the user's installed app while `which` worked in Terminal. As a
- * final fallback it consults the user's login shell (`<shell> -lc 'command -v
- * <name>'`) so custom profile PATHs (rbenv/asdf/fnm) resolve exactly as in
- * their Terminal. Returns the absolute path, or an error if not found.
+ * process PATH, then an explicit baseline of tool dirs that a GUI-launched
+ * app's stripped PATH omits — on macOS Homebrew on either arch, `~/.local/bin`,
+ * bun/cargo/volta/deno, every nvm node version (this is why detection found
+ * nothing on the user's installed app while `which` worked in Terminal); on
+ * Windows `%APPDATA%\npm`, `%LOCALAPPDATA%\Programs`, bun/volta/cargo/scoop
+ * and `%ProgramFiles%\nodejs`, probing PATHEXT-style candidate names
+ * (`claude.cmd` etc.). As a final fallback it consults the user's login shell
+ * (`<shell> -lc 'command -v <name>'`; `where.exe` on Windows) so custom
+ * profile PATHs (rbenv/asdf/fnm) resolve exactly as in their Terminal.
+ * Returns the absolute path, or an error if not found.
  */
 async detectAgentBinary(cliType: AgentCliType) : Promise<Result<string, string>> {
     try {
@@ -1490,6 +1493,78 @@ async downloadDiarizationModels() : Promise<Result<null, string>> {
 }
 },
 /**
+ * Pair this device with a self-hosted OpenFlow Service.
+ * 
+ * On `201`: store the returned `device_token` in the OS keyring, persist the URL,
+ * set `service_enabled = true`, record the device identity, and start the sync
+ * worker. On any error: friendly message, nothing persisted.
+ */
+async pairService(url: string, setupToken: string) : Promise<Result<PairedDeviceInfo, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("pair_service", { url, setupToken }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Unpair: best-effort revoke on the server, then remove the local token and
+ * disable the feature. Always succeeds locally even if the server is unreachable.
+ */
+async unpairService() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("unpair_service") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Current status for the settings UI.
+ */
+async serviceStatus() : Promise<Result<ServiceStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("service_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Test the connection with the stored token: `GET /v1/info`.
+ */
+async testServiceConnection() : Promise<Result<ServiceInfo, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("test_service_connection") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Toggle transcript sync (privacy-critical opt-in). Also nudges the worker so a
+ * freshly-enabled sync starts promptly.
+ */
+async setServiceSyncTranscripts(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_service_sync_transcripts", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Toggle usage-event sync (counts/durations only — never text).
+ */
+async setServiceSyncUsage(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_service_sync_usage", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Checks if the Mac is a laptop by detecting battery presence
  * 
  * This uses pmset to check for battery information.
@@ -1938,7 +2013,33 @@ meetings_diarization?: boolean;
  * infeasible past a few minutes, so the safe default is final-pass-only
  * (DESIGN-meetings.md §5.4 auto-degrade). Users on fast machines can opt in.
  */
-meetings_diarization_provisional?: boolean }
+meetings_diarization_provisional?: boolean; 
+/**
+ * Base URL of the paired self-hosted OpenFlow Service (e.g.
+ * `https://openflow.example.com`). Empty = feature fully dormant: no sync
+ * worker is ever started and nothing leaves the machine. The device token
+ * itself is NEVER stored here — it lives in the OS keyring (scope
+ * `"service"`, account `"device_token"`); this struct only holds the URL and
+ * opt-in flags. All four fields are `#[serde(default)]` so an old settings
+ * store (with none of these keys) deserializes byte-for-byte as before.
+ */
+service_url?: string; 
+/**
+ * Whether a device is paired and the integration is active. Set true only on
+ * a successful `pair_service`; cleared by `unpair_service`. When false the
+ * sync worker does nothing even if a URL is present.
+ */
+service_enabled?: boolean; 
+/**
+ * Opt-in: push dictation transcript TEXT to the service. Default OFF. When
+ * false, transcript text NEVER leaves the machine (privacy rule).
+ */
+service_sync_transcripts?: boolean; 
+/**
+ * Opt-in: push usage events (dictation counts/durations, NO text) to the
+ * service. Default OFF. Independent of `service_sync_transcripts`.
+ */
+service_sync_usage?: boolean }
 export type AppUsage = { app: string; dictations: number; words: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
@@ -2181,6 +2282,10 @@ export type OverlayPosition = "top" | "bottom"
  */
 export type OverlayStyle = "none" | "minimal" | "live"
 export type PaginatedHistory = { entries: HistoryEntry[]; has_more: boolean }
+/**
+ * Returned to the UI after a successful pairing.
+ */
+export type PairedDeviceInfo = { device_id: string; device_name: string; url: string }
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v" | "external_script"
 export type PermissionAccess = "allowed" | "denied" | "unknown"
 export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean }
@@ -2204,6 +2309,30 @@ export type RunStatus = { status: "running" } | { status: "finished"; code: numb
  */
 export type RunningApp = { bundle_id: string; name: string }
 export type SecretMap = Partial<{ [key in string]: string }>
+/**
+ * Typed result of a connection test / info fetch.
+ */
+export type ServiceInfo = { version: string; edition: string; module_stt: boolean; module_llm: boolean; module_memory: boolean }
+/**
+ * Status snapshot for the settings UI.
+ */
+export type ServiceStatus = { 
+/**
+ * A URL is configured (feature is at least half-set-up).
+ */
+configured: boolean; 
+/**
+ * A device is paired and the integration is active.
+ */
+enabled: boolean; url: string; sync_transcripts: boolean; sync_usage: boolean; paired_device_name: string | null; 
+/**
+ * Unix seconds of the last successful push, if any.
+ */
+last_sync_at: number | null; 
+/**
+ * History rows not yet synced (informational).
+ */
+pending_count: number | null }
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }
 export type SoundTheme = "marimba" | "pop" | "custom"
 /**

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   BookA,
   Radar,
   Video,
+  Cloud,
 } from "lucide-react";
 import { useSettings } from "../hooks/useSettings";
 import openflowLogo from "../assets/openflow-logo.png";
@@ -35,6 +36,7 @@ import {
   AgentRunsSettings,
   MissionControlSettings,
   MeetingsSettings,
+  ServiceSettings,
 } from "./settings";
 
 export type SidebarSection = keyof typeof SECTIONS_CONFIG;
@@ -167,6 +169,13 @@ export const SECTIONS_CONFIG = {
     group: "meetings",
   },
   // --- System ---
+  service: {
+    labelKey: "sidebar.service",
+    icon: Cloud,
+    component: ServiceSettings,
+    enabled: () => true,
+    group: "system",
+  },
   handsFree: {
     labelKey: "sidebar.handsFree",
     icon: Ear,

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -15,6 +15,7 @@ export { ModelSetupSettings } from "./model-setup/ModelSetupSettings";
 export { DashboardSettings } from "./dashboard/DashboardSettings";
 export { HandsFreeSettings } from "./hands-free/HandsFreeSettings";
 export { MissionControlSettings } from "./mission-control/MissionControlSettings";
+export { ServiceSettings } from "./service/ServiceSettings";
 
 // Individual setting components
 export { MicrophoneSelector } from "./MicrophoneSelector";

--- a/src/components/settings/service/ServiceSettings.tsx
+++ b/src/components/settings/service/ServiceSettings.tsx
@@ -1,0 +1,290 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Cloud, Link2, Loader2, ShieldCheck, Unlink } from "lucide-react";
+import type { ServiceStatus, ServiceInfo } from "@/bindings";
+import { commands } from "@/bindings";
+import { Button } from "../../ui/Button";
+import { Input } from "../../ui/Input";
+import { SettingsGroup } from "../../ui/SettingsGroup";
+import { ToggleSwitch } from "../../ui/ToggleSwitch";
+
+/**
+ * OpenFlow Service — "Connect to my service".
+ *
+ * Additive, dormant-by-default integration: pair this device with a self-hosted
+ * OpenFlow Service, then opt in (per data type) to sync dictation transcripts
+ * and/or usage events. Nothing leaves the machine until the user pairs AND turns
+ * a sync on. The device token lives in the OS keyring (backend); this UI only
+ * ever sees the URL, device name and opt-in flags.
+ */
+export const ServiceSettings: React.FC = () => {
+  const { t } = useTranslation();
+
+  const [status, setStatus] = useState<ServiceStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Unpaired-form state.
+  const [url, setUrl] = useState("");
+  const [setupToken, setSetupToken] = useState("");
+  const [pairing, setPairing] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [unpairing, setUnpairing] = useState(false);
+  const [info, setInfo] = useState<ServiceInfo | null>(null);
+
+  const refresh = useCallback(async () => {
+    const result = await commands.serviceStatus();
+    if (result.status === "ok") {
+      setStatus(result.data);
+      // Pre-fill the URL field from any previously-configured value.
+      setUrl((prev) => (prev.length === 0 ? result.data.url : prev));
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    void refresh().finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
+
+  const handlePair = async () => {
+    setPairing(true);
+    setInfo(null);
+    try {
+      const result = await commands.pairService(url.trim(), setupToken.trim());
+      if (result.status === "error") {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(
+        t("settings.service.pairedToast", { name: result.data.device_name }),
+      );
+      setSetupToken("");
+      await refresh();
+    } finally {
+      setPairing(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setInfo(null);
+    try {
+      const result = await commands.testServiceConnection();
+      if (result.status === "error") {
+        toast.error(result.error);
+        return;
+      }
+      setInfo(result.data);
+      toast.success(
+        t("settings.service.testOk", { version: result.data.version }),
+      );
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleUnpair = async () => {
+    setUnpairing(true);
+    try {
+      const result = await commands.unpairService();
+      if (result.status === "error") {
+        toast.error(result.error);
+        return;
+      }
+      setInfo(null);
+      toast.success(t("settings.service.unpairedToast"));
+      await refresh();
+    } finally {
+      setUnpairing(false);
+    }
+  };
+
+  const handleToggleTranscripts = async (checked: boolean) => {
+    const result = await commands.setServiceSyncTranscripts(checked);
+    if (result.status === "error") {
+      toast.error(result.error);
+      return;
+    }
+    await refresh();
+  };
+
+  const handleToggleUsage = async (checked: boolean) => {
+    const result = await commands.setServiceSyncUsage(checked);
+    if (result.status === "error") {
+      toast.error(result.error);
+      return;
+    }
+    await refresh();
+  };
+
+  const paired = status?.enabled ?? false;
+
+  return (
+    <div className="max-w-3xl w-full mx-auto space-y-6">
+      <SettingsGroup
+        title={t("settings.service.title")}
+        description={t("settings.service.intro")}
+      >
+        {/* Privacy note — always visible. */}
+        <div className="px-4 py-3 flex items-start gap-2 text-xs text-mid-gray border-b border-mid-gray/15">
+          <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5 text-logo-primary" />
+          <span>{t("settings.service.privacyNote")}</span>
+        </div>
+
+        {loading ? (
+          <div className="px-4 py-6 flex items-center gap-2 text-sm text-mid-gray">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("settings.service.loading")}
+          </div>
+        ) : paired ? (
+          // ---- Paired state ----
+          <div className="px-4 py-4 space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <Cloud className="h-4 w-4 text-logo-primary" />
+                  {status?.paired_device_name ??
+                    t("settings.service.thisDevice")}
+                </div>
+                <p className="text-xs text-mid-gray truncate mt-0.5">
+                  {status?.url}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="danger-ghost"
+                size="sm"
+                onClick={() => void handleUnpair()}
+                disabled={unpairing}
+                className="inline-flex items-center gap-1.5"
+              >
+                {unpairing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Unlink className="h-4 w-4" />
+                )}
+                {t("settings.service.unpair")}
+              </Button>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => void handleTest()}
+                disabled={testing}
+                className="inline-flex items-center gap-1.5"
+              >
+                {testing && <Loader2 className="h-4 w-4 animate-spin" />}
+                {t("settings.service.testConnection")}
+              </Button>
+              {info && (
+                <span className="text-xs text-mid-gray">
+                  {t("settings.service.infoLine", {
+                    version: info.version,
+                    edition: info.edition,
+                  })}
+                </span>
+              )}
+            </div>
+          </div>
+        ) : (
+          // ---- Unpaired state ----
+          <div className="px-4 py-4 space-y-3">
+            <label className="block space-y-1">
+              <span className="text-xs font-medium text-mid-gray">
+                {t("settings.service.urlLabel")}
+              </span>
+              <Input
+                type="text"
+                inputMode="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder={t("settings.service.urlPlaceholder")}
+                variant="compact"
+                className="w-full"
+              />
+            </label>
+            <label className="block space-y-1">
+              <span className="text-xs font-medium text-mid-gray">
+                {t("settings.service.setupTokenLabel")}
+              </span>
+              <Input
+                type="password"
+                value={setupToken}
+                onChange={(e) => setSetupToken(e.target.value)}
+                placeholder={t("settings.service.setupTokenPlaceholder")}
+                variant="compact"
+                className="w-full"
+              />
+            </label>
+            <div className="flex items-center gap-2 pt-1">
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => void handlePair()}
+                disabled={
+                  pairing ||
+                  url.trim().length === 0 ||
+                  setupToken.trim().length === 0
+                }
+                className="inline-flex items-center gap-1.5"
+              >
+                {pairing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Link2 className="h-4 w-4" />
+                )}
+                {t("settings.service.pair")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </SettingsGroup>
+
+      {/* Sync options — only meaningful once paired. */}
+      {paired && (
+        <SettingsGroup title={t("settings.service.syncTitle")}>
+          <ToggleSwitch
+            checked={status?.sync_transcripts ?? false}
+            onChange={(checked) => void handleToggleTranscripts(checked)}
+            label={t("settings.service.syncTranscripts")}
+            description={t("settings.service.syncTranscriptsHint")}
+            descriptionMode="inline"
+            grouped
+          />
+          <ToggleSwitch
+            checked={status?.sync_usage ?? false}
+            onChange={(checked) => void handleToggleUsage(checked)}
+            label={t("settings.service.syncUsage")}
+            description={t("settings.service.syncUsageHint")}
+            descriptionMode="inline"
+            grouped
+          />
+          <div className="px-4 py-3 border-t border-mid-gray/15 flex items-center justify-between gap-3 text-xs text-mid-gray">
+            <span>
+              {status?.last_sync_at
+                ? t("settings.service.lastSync", {
+                    when: new Date(status.last_sync_at * 1000).toLocaleString(),
+                  })
+                : t("settings.service.neverSynced")}
+            </span>
+            <span className="tabular-nums">
+              {t("settings.service.pending", {
+                count: status?.pending_count ?? 0,
+              })}
+            </span>
+          </div>
+        </SettingsGroup>
+      )}
+    </div>
+  );
+};

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -33,7 +33,8 @@
       "agents": "Agents",
       "meetings": "Meetings",
       "system": "System"
-    }
+    },
+    "service": "OpenFlow Service"
   },
   "onboarding": {
     "subtitle": "To get started, choose a transcription model",
@@ -1307,6 +1308,32 @@
         "meetingCapture": "Meeting capture",
         "showHotkeys": "Show hotkeys"
       }
+    },
+    "service": {
+      "title": "OpenFlow Service",
+      "intro": "Connect this device to your own self-hosted OpenFlow Service to sync dictation history and usage across your machines.",
+      "privacyNote": "Nothing is sent unless you turn it on. Your service, your data.",
+      "loading": "Checking connection…",
+      "thisDevice": "This device",
+      "urlLabel": "Service URL",
+      "urlPlaceholder": "https://openflow.example.com",
+      "setupTokenLabel": "Setup token",
+      "setupTokenPlaceholder": "Paste the setup token from your service",
+      "pair": "Pair",
+      "unpair": "Unpair",
+      "testConnection": "Test connection",
+      "infoLine": "{{edition}} · v{{version}}",
+      "pairedToast": "Paired as {{name}}",
+      "unpairedToast": "This device has been unpaired.",
+      "testOk": "Connected to OpenFlow Service v{{version}}",
+      "syncTitle": "Sync",
+      "syncTranscripts": "Sync transcripts",
+      "syncTranscriptsHint": "Push dictation transcript text to your service. Off by default — when off, transcript text never leaves this machine.",
+      "syncUsage": "Sync usage",
+      "syncUsageHint": "Push usage events (dictation counts and durations only — never text) to your service.",
+      "lastSync": "Last sync: {{when}}",
+      "neverSynced": "Not synced yet",
+      "pending": "{{count}} pending"
     }
   },
   "footer": {


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

> **Stacked PR.** Base is `fix/codex-run-diagnostics` (PR #41), per the agreed
> sequencing — it retargets to `main` automatically when #41 merges. This PR does
> **not** touch either file #41 changes (`src-tauri/src/managers/agent_run.rs`,
> `src-tauri/src/commands/agent_runs.rs`).

## Human Written Description

<!-- FOUNDER TODO (avijeett007): replace this block with 2-3 sentences in your own
     voice — what problem you saw and why the self-hosted "Connect to my service"
     integration matters to you. This is a placeholder written by the AI assistant
     and must not ship as your words. -->

## Related Issues

Implements the desktop half of `DESIGN-openflow-service.md` §8 (frozen contract).

Fixes #

## Testing

Platform: macOS (Intel), Rust + Bun toolchain.

**Feature works (added, present):**
- `cargo test --lib` — **318 passed, 0 failed** (306 baseline + 12 new). New pure-logic
  tests cover batching into ≤50 chunks, `client_id` stability (rowid, shared by the
  transcript + usage push), exponential backoff progression (30s→60→120→240→300 cap),
  RFC3339 timestamp rendering, "usage payload never contains transcript text", pair
  request-body construction/serialization, and error-status → friendly-message mapping.
- `cargo clippy --lib` — no new warnings in touched files.
- `cargo fmt` / `bun run format:check` — clean.
- `bun run build` (tsc + vite) — compiles, strict TS, no `any`.
- `bun run lint` — no new errors (the single remaining warning is pre-existing in
  `devAutomation.ts`).
- `src/bindings.ts` regenerated via the documented specta-export method.

**Non-breaking / regression half (behavior unchanged with the feature present AND
absent/unconfigured):**
- New settings test `legacy_store_without_service_fields_defaults_them_off` deserializes
  a pre-service settings blob (no `service_*` keys) and asserts `service_url == ""` and
  all three flags `false` — proving old settings files load byte-for-byte unchanged and
  nothing is ever synced until the user explicitly pairs and opts in.
- No core-path file was changed. The dictation loop (hotkey → capture → STT → cleanup →
  inject) and its files are untouched. Touched files (proof):
  - `src-tauri/src/settings.rs` (4 additive `#[serde(default)]` fields + defaults + test)
  - `src-tauri/src/commands/service.rs` (new)
  - `src-tauri/src/commands/mod.rs` (module registration)
  - `src-tauri/src/managers/service_sync.rs` (new sibling worker)
  - `src-tauri/src/managers/mod.rs` (module registration)
  - `src-tauri/src/lib.rs` (manage state, register commands, gated start)
  - `src/components/settings/service/ServiceSettings.tsx` (new)
  - `src/components/settings/index.ts`, `src/components/Sidebar.tsx` (new section)
  - `src/i18n/locales/en/translation.json`, `src/bindings.ts`
- The sync worker is only ever spawned when `service_enabled && !service_url.is_empty()`,
  reads the history SQLite **READ-ONLY** (its own `service_sync.db` holds the cursor), and
  never runs inside the dictation path. Privacy rule enforced: transcript text leaves the
  machine only when `service_sync_transcripts` is on; usage events carry counts/durations
  only.

## Screenshots/Videos (if applicable)

Not captured in this session (headless). The new "OpenFlow Service" section renders under
the **System** group in Settings; unpaired state shows URL + setup-token + Pair, paired
state shows device/URL, Test connection, sync toggles, last-sync + pending count, Unpair.

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus).
- How extensively: AI wrote the implementation (Rust backend, sync worker, commands,
  React UI, i18n, tests) against the frozen contract. A human founder must fill in the
  "Human Written Description" above and review before merge.
