### PR TITLE
fix(deps): revert windows crate to 0.61.3; pin tauri-action; drop dead uploadUpdaterJson/Signatures inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,12 +180,26 @@ jobs:
       # updater's *minisign* key: with them set (and createUpdaterArtifacts=true)
       # the bundler emits the updater archives AND a `.sig` next to each one.
       #
-      # uploadUpdaterJson is OFF on purpose: each matrix job only knows its own
-      # platform, so letting tauri-action write latest.json would have all three
-      # jobs clobber it down to a single platform. The `publish` job assembles a
-      # correct multi-platform latest.json from every job's signatures instead.
+      # includeUpdaterJson defaults to false, which is what we want: each matrix
+      # job only knows its own platform, so letting tauri-action write
+      # latest.json would have all three jobs clobber it down to a single
+      # platform. The `publish` job assembles a correct multi-platform
+      # latest.json from every job's signatures instead, and uploads the
+      # per-arch archives + `.sig` under deterministic names (macOS archives are
+      # otherwise all named `OpenFlow.app.tar.gz` and would collide across the
+      # two mac jobs).
+      #
+      # NOTE: this step used to also pass `uploadUpdaterJson: false` and
+      # `uploadUpdaterSignatures: false`. Neither input has ever existed on
+      # tauri-action (verified against action.yml back to v0.5.0) — GitHub
+      # Actions silently drops unrecognized `with:` inputs, so they were always
+      # no-ops. A more recent v0.6.x picked up an explicit
+      # "Unexpected input(s)" warning annotation for this, which is what
+      # surfaced on the v0.15.2 build (on all three platforms, including the
+      # two that succeeded — this warning alone never failed a build). Removed
+      # them here since they did nothing; behavior is unchanged.
       - name: Build with Tauri
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@1ddc7b49b13c3038297360482fcb3e058764d7c9 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -195,12 +209,6 @@ jobs:
           releaseName: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
           releaseDraft: true
           prerelease: false
-          # Both OFF: the `publish` job owns the updater assets. It uploads the
-          # per-arch archives + `.sig` under deterministic names (macOS archives
-          # are otherwise all named `OpenFlow.app.tar.gz` and would collide across
-          # the two mac jobs) and writes the multi-platform latest.json.
-          uploadUpdaterJson: false
-          uploadUpdaterSignatures: false
           args: ${{ matrix.args }}
 
       # How the Intel .app links ONNX Runtime is NOT fixed — it depends on what

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4062,7 +4062,7 @@ dependencies = [
  "transcribe-cpp",
  "transcribe-rs",
  "vad-rs",
- "windows 0.62.2",
+ "windows 0.61.3",
  "winreg 0.55.0",
 ]
 
@@ -8011,23 +8011,11 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -8037,15 +8025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8085,19 +8064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8105,18 +8071,7 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading 0.1.0",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -8183,16 +8138,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8394,15 +8339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -116,7 +116,21 @@ tauri-plugin-updater = "2.10.0"
 # link a baseline ONNX Runtime (dynamically, via ORT_LIB_LOCATION in build.yml)
 # with proper runtime CPU dispatch. Base `transcribe-rs` (features = ["onnx"])
 # is inherited here, so Parakeet/Moonshine/etc. still run on CPU.
-windows = { version = "0.62.2", features = [
+#
+# PINNED to 0.61.3 (not the latest 0.62.x): tauri 2.10.2's own dependency
+# graph (tao/wry/webview2-com/tauri-runtime) is locked to `windows` 0.61.3.
+# windows-rs does not treat minor bumps as ABI/type-compatible — each
+# version mints distinct nominal types (HWND, etc.) — so pulling 0.62.x here
+# put TWO incompatible `windows` crates in the graph. `overlay.rs`'s
+# `force_overlay_topmost` mixed the app's 0.62.2 `SetWindowPos`/HWND_TOPMOST
+# with the HWND returned by `tauri::WebviewWindow::hwnd()` (tauri's vendored
+# 0.61.3), which rustc rightly rejected as a type mismatch (E0308). This
+# broke the v0.15.2 Windows release build. Keep this pinned to whatever
+# version tauri's own `windows` dependency resolves to; bump only alongside
+# a tauri upgrade, and re-run `cargo tree -i windows --target
+# x86_64-pc-windows-msvc` to confirm there's a single `windows` version in
+# the graph before merging.
+windows = { version = "0.61.3", features = [
   "Win32_Media_Audio_Endpoints",
   "Win32_System_Com_StructuredStorage",
   "Win32_System_Variant",


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/avijeett007/openflow/issues) and [pull requests](https://github.com/avijeett007/openflow/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/avijeett007/openflow/blob/main/CONTRIBUTING.md)

## Human Written Description

<!-- TODO(maintainer): please replace this with 2-3 sentences in your own words —
what you noticed and why this matters. Left as a placeholder per AGENTS.md
("do not invent their voice"); the investigation below is AI-written. -->

TODO: maintainer to fill in.

## Related Issues

Fixes # (the v0.15.2 release build failure — draft release stuck at 7/11 assets, no tracked issue number; opened directly against the failed run)

## Root cause (verified from CI logs, not the originally-suspected cause)

The v0.15.2 tag build ([run 29778483734](https://github.com/avijeett007/openflow/actions/runs/29778483734)) failed on `Build (x86_64-pc-windows-msvc)`. The initial hypothesis was the `tauri-action` "Unexpected input(s)" warning or the cache rate-limit. Pulling the actual job log (`gh api /repos/avijeett007/openflow/actions/jobs/88476194211/logs`) shows neither of those was fatal — the real failure is a **Rust compile error**, introduced by PR #47's dependency bumps:

```
2026-07-20T21:23:46.8552391Z error[E0308]: mismatched types
2026-07-20T21:23:46.8552923Z     --> src\overlay.rs:171:21
2026-07-20T21:23:46.8553309Z      |
2026-07-20T21:23:46.8553700Z  170 |                 let _ = SetWindowPos(
2026-07-20T21:23:46.8554310Z      |                         ------------ arguments to this function are incorrect
2026-07-20T21:23:46.8554861Z  171 |                     hwnd,
2026-07-20T21:23:46.8555721Z      |                     ^^^^ expected `HWND`, found `windows::Win32::Foundation::HWND`
2026-07-20T21:23:46.8556248Z      |
2026-07-20T21:23:46.8556786Z note: there are multiple different versions of crate `windows` in the dependency graph
2026-07-20T21:23:46.8557763Z     --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows-0.62.2\src\Windows\Win32\Foundation\mod.rs:5670:1
2026-07-20T21:23:46.8558896Z 5670 | pub struct HWND(pub *mut core::ffi::c_void);
2026-07-20T21:23:46.8558423Z     ::: C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows-0.61.3\src\Windows\Win32\Foundation\mod.rs:5670:1
2026-07-20T21:23:46.8561926Z 5670 | pub struct HWND(pub *mut core::ffi::c_void);
2026-07-20T21:23:52.1549389Z error: could not compile `openflow` (lib) due to 1 previous error; 1 warning emitted
2026-07-20T21:23:52.3948713Z failed to build app: failed to build app
2026-07-20T21:23:52.4151772Z ##[error]Command "bun ["tauri","build","--target","x86_64-pc-windows-msvc"]" failed with exit code 1
```

PR #47 (dependabot-authored, human-consolidated) bumped `windows` in `src-tauri/Cargo.toml` from `0.61.3` to `0.62.2` ("semver-minor" per dependabot, but windows-rs mints a **distinct nominal type per version** — it does not treat minor bumps as type-compatible). tauri 2.10.2's own stack (`tao` → `tauri-runtime-wry` → `tauri`, plus `webview2-com`) is locked to `windows 0.61.3`, and `enigo` also pulls `0.61.3`. Bumping only the app's direct dependency put **two incompatible `windows` crates** in the graph:

```
$ cargo tree -i windows@0.61.3 --target x86_64-pc-windows-msvc
windows v0.61.3
├── enigo v0.6.1 └── openflow v0.15.2
├── tao v0.34.5 └── tauri-runtime-wry → tauri v2.10.2 (+ 13 tauri-plugin-* crates)
├── tauri v2.10.2
├── tauri-runtime v2.10.0
├── tauri-winrt-notification v0.7.3 (via notify-rust)
└── webview2-com v0.38.2
```

`src-tauri/src/overlay.rs`'s `force_overlay_topmost` calls `windows::Win32::UI::WindowsAndMessaging::SetWindowPos` (resolved against the app's direct `windows 0.62.2` dep) with the `HWND` returned by `tauri::WebviewWindow::hwnd()` (tauri's vendored `windows 0.61.3`). rustc correctly rejects mixing the two nominally-distinct `HWND` types — exactly the `E0308` above. `v0.15.1` (the last successful release) was on `windows 0.61.3`, confirming this is the regression.

The `tauri-action` "Unexpected input(s) 'uploadUpdaterJson', 'uploadUpdaterSignatures'" line and the `swatinem/rust-cache` "Rate limited: ... 429 Too Many Requests" line are both `##[warning]` annotations, not `##[error]` — they appear on **all three** matrix jobs (including the two that succeeded: `aarch64-apple-darwin`, `x86_64-apple-darwin`), and the "Cache Rust build" step is marked successful in the job summary despite the rate-limit warning (`swatinem/rust-cache` treats a failed cache restore as non-fatal by design — it just proceeds with a cold cache). Neither contributed to the Windows job's failure. I fixed the tauri-action inputs anyway (real hygiene debt, see below) but left the cache step untouched since it's already non-fatal and disabling/wrapping it would be a no-op change.

## Changes

1. **`src-tauri/Cargo.toml` / `src-tauri/Cargo.lock`** (the actual fix): reverted `windows` from `0.62.2` back to `0.61.3` via `cargo update -p windows@0.62.2 --precise 0.61.3`, matching tauri's own dependency and the last shipped release (`v0.15.1`). Verified with `cargo tree -i windows --target x86_64-pc-windows-msvc` that only one `windows` version remains in the graph, and `cargo metadata --locked` resolves cleanly. Left a comment in `Cargo.toml` explaining the pin so a future dependabot bump doesn't reintroduce the diamond silently — bumping `windows` now needs to happen alongside a `tauri` upgrade, re-verified with the same `cargo tree -i` command.
2. **`.github/workflows/build.yml`**:
   - Removed the `uploadUpdaterJson: false` / `uploadUpdaterSignatures: false` inputs from the "Build with Tauri" step. These inputs have **never existed** on `tauri-action` (checked `action.yml` back to `v0.5.0` — only `includeUpdaterJson` exists); GitHub Actions silently drops unrecognized `with:` inputs, so they were always no-ops, and the `publish` job already owns assembling `latest.json` + uploading the per-arch archives/sigs, exactly as the (now-updated) comment says.
   - Fixed the stale comment that said "Both OFF" (referring to the two removed inputs) to instead explain that `includeUpdaterJson` already defaults to `false`, which is what's wanted.
   - Pinned `tauri-apps/tauri-action` from the floating `@v0` tag to the commit SHA for `v0.6.2` (`1ddc7b49b13c3038297360482fcb3e058764d7c9`) — the same version `@v0` already resolves to today, so this is a reproducibility pin, not a behavior change. Checked `tauri-action`'s tags: a `v1.0.0` exists (published 2026-06-29) but I did **not** jump to it — an untested major bump is out of scope for a build-unblock fix; `v0.6.2`'s changelog (`#1288`, workspace-root detection) is unrelated to our failure.
   - Left `actions/upload-artifact@v7` (producer) / `actions/download-artifact@v8` (consumer) unchanged: both ship on the same modern `@actions/artifact` backend (v4+), this is the officially-recommended pairing, and the Windows job never reached those steps (it died at compile time) so the logs have no evidence of a mismatch. No change needed.

## Testing

- `gh api /repos/avijeett007/openflow/actions/jobs/88476194211/logs` — pulled the raw Windows job log and located the actual fatal error (E0308, not the tauri-action warning).
- `cargo tree -i windows@0.61.3 --target x86_64-pc-windows-msvc` (before/after) — confirmed the diamond before the fix, confirmed a single unified `windows 0.61.3` after.
- `cargo metadata --format-version=1 --locked` — passes, confirming `Cargo.lock` is self-consistent with `Cargo.toml` (no lockfile drift).
- `git show v0.15.1:src-tauri/Cargo.toml` — confirmed the last successful release was on `windows 0.61.3`, corroborating the regression.
- YAML validity: `bunx js-yaml .github/workflows/build.yml` — parses cleanly.
- `bun run format:check` — passes (prettier + `cargo fmt --check`), exit code 0.
- Not run: an actual `x86_64-pc-windows-msvc` cross-build (no MSVC cross-toolchain on this macOS dev machine; only the CI Windows runner can fully validate). This PR's own `build.yml` run against this branch is the real verification — please confirm the Windows job goes green before considering this fix proven.

## Screenshots/Videos (if applicable)

N/A — CI/dependency fix, no UI change.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Sonnet 5), diagnosing via `gh` CLI (run/job logs, job/step status) and `cargo tree`/`cargo metadata` against the local checkout.
- How extensively: AI performed the entire investigation (log retrieval, root-cause isolation, `cargo tree` diamond-dependency analysis, comparison against `v0.15.1`) and wrote the full diff (`Cargo.toml`, regenerated `Cargo.lock` via `cargo update -p windows@0.62.2 --precise 0.61.3`, and `build.yml`) and this PR description. A maintainer has not yet reviewed the reasoning or watched the Windows job re-run green.

## Post-merge plan

Per the orchestrator's release discipline (`RELEASES.md`): this PR only fixes `main`. It does **not** touch the stuck `v0.15.2` draft release or tag. Once merged, the orchestrator will delete the draft `v0.15.2` release + tag and re-tag `v0.15.2` on the fixed `main` to trigger a clean build → publish.
