### PR TITLE
feat(agents): verify + fix OpenClaw and Hermes CLI agent support

### DIFF
--- a/src-tauri/src/managers/agent_run.rs
+++ b/src-tauri/src/managers/agent_run.rs
@@ -779,6 +779,16 @@ fn parse_semver_key(name: &str) -> Vec<u64> {
 /// self-contained native binary at `$HOME/.kimi-code/bin/kimi` and only adds it
 /// to PATH via the user's shell rc file (`.bash_profile`/`.zshrc`), which a
 /// GUI-launched app never sources.
+///
+/// `.openclaw/bin` is one of OpenClaw's own install locations — LIVE-VERIFIED:
+/// its `install-cli.sh` variant writes the wrapper to `<prefix>/bin/openclaw`
+/// with a default prefix of `~/.openclaw`. (A plain `npm install -g openclaw`,
+/// used for this PR's live verification, instead lands in npm's global bin —
+/// already covered by `.local/bin`/Homebrew/`STATIC_BASELINE_DIRS` below — but
+/// the dedicated-prefix installer path is not, so it's added defensively.)
+/// Hermes needs no new entry: its installer (LIVE-VERIFIED,
+/// `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`)
+/// symlinks to `~/.local/bin/hermes`, already in this list.
 pub fn baseline_bin_dirs(
     windows: bool,
     env: &impl Fn(&str) -> Option<String>,
@@ -812,9 +822,10 @@ pub fn baseline_bin_dirs(
         if let Some(home) = get("HOME") {
             // Common per-user install locations that a stripped launchd PATH omits.
             for sub in [
-                ".local/bin",       // native installers (incl. Claude Code native)
+                ".local/bin",       // native installers (incl. Claude Code native, Hermes)
                 ".claude/local",    // Claude Code local install
                 ".kimi-code/bin",   // Kimi Code CLI native install
+                ".openclaw/bin",    // OpenClaw install-cli.sh default prefix
                 ".bun/bin",         // Bun global bins
                 ".cargo/bin",       // Rust/cargo
                 ".volta/bin",       // Volta-managed node tools
@@ -1390,6 +1401,48 @@ mod tests {
     }
 
     #[test]
+    fn build_argv_openclaw_template_delivers_prompt_as_single_arg() {
+        // Regression test for the verified default OpenClaw template:
+        // `-m/--message` takes the instruction as ONE argv element. A
+        // multi-word instruction must reach argv as a single element right
+        // after `--message`, never re-split on its spaces.
+        let argv = build_argv(
+            "agent --local --agent main --message {prompt}",
+            "/tmp/proj",
+            "list all the files",
+            PromptDelivery::Arg,
+        );
+        assert_eq!(
+            argv,
+            vec![
+                "agent",
+                "--local",
+                "--agent",
+                "main",
+                "--message",
+                "list all the files"
+            ]
+        );
+        assert_eq!(argv.len(), 6);
+        assert_eq!(argv[5], "list all the files");
+    }
+
+    #[test]
+    fn build_argv_hermes_template_delivers_prompt_as_single_arg() {
+        // Regression test for the verified default Hermes template: `-z`
+        // takes the instruction as ONE argv element right after it.
+        let argv = build_argv(
+            "-z {prompt} --yolo",
+            "/tmp/proj",
+            "list all the files",
+            PromptDelivery::Arg,
+        );
+        assert_eq!(argv, vec!["-z", "list all the files", "--yolo"]);
+        assert_eq!(argv.len(), 3);
+        assert_eq!(argv[1], "list all the files");
+    }
+
+    #[test]
     fn build_argv_stdin_drops_bare_prompt_but_keeps_other_args() {
         let argv = build_argv("run {prompt} --flag", "/x", "hi", PromptDelivery::Stdin);
         assert_eq!(argv, vec!["run", "--flag"]);
@@ -1472,6 +1525,8 @@ mod tests {
         // Kimi Code CLI's own install location (its installer only updates a
         // shell rc file, which a GUI-launched app never sources).
         assert!(dirs.contains(&"/Users/me/.kimi-code/bin".to_string()));
+        // OpenClaw's install-cli.sh default prefix (`~/.openclaw/bin`).
+        assert!(dirs.contains(&"/Users/me/.openclaw/bin".to_string()));
         // Both arch Homebrew prefixes + system dirs.
         assert!(dirs.contains(&"/opt/homebrew/bin".to_string()));
         assert!(dirs.contains(&"/usr/local/bin".to_string()));

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -193,8 +193,8 @@ pub fn default_cli_binary_name(cli_type: AgentCliType) -> Option<&'static str> {
 /// --verbose` runs headless and streams line-delimited JSON; `acceptEdits`
 /// auto-accepts file edits so the agent can actually modify the repo without an
 /// interactive permission prompt (git is the safety net, per DESIGN §9). The
-/// instruction is delivered on stdin (no arg-length limit). codex/openclaw/
-/// hermes are best-effort (binaries not installed here — see BLOCKERS).
+/// instruction is delivered on stdin (no arg-length limit). Codex is
+/// best-effort (binary not installed here — see BLOCKERS).
 ///
 /// Kimi Code's flags are LIVE-VERIFIED against `kimi-code` 0.28.1: `-p/--prompt`
 /// takes the instruction as an ARGUMENT value (not stdin), so `prompt_via` is
@@ -210,6 +210,48 @@ pub fn default_cli_binary_name(cli_type: AgentCliType) -> Option<&'static str> {
 /// `{"type": "system"|"assistant"|"user"|"result"}` events
 /// `parseAgentOutput.ts` recognizes, so `text` renders as clean human-readable
 /// output via the raw-output fallback instead of unparsed JSON lines.
+///
+/// OpenClaw's flags are LIVE-VERIFIED against `openclaw` 2026.7.1-2 (installed
+/// via `npm install -g openclaw@latest`; requires Node >=22.22.3<23,
+/// >=24.15.0<25, or >=25.9.0 — the CLI hard-refuses to start otherwise with an
+/// actionable nvm hint, a gotcha only found by actually launching it).
+/// OpenClaw is architecturally a persistent messaging-channel gateway/daemon,
+/// not a one-shot project CLI like Claude/Codex/Kimi: `openclaw agent --local`
+/// is its closest headless equivalent (embedded run, no Gateway process
+/// required) but it addresses a **named agent identity** (`--agent <id>`),
+/// not an arbitrary `{cwd}` — `openclaw agent --help` has no `--dir`/`--cwd`
+/// flag at all. Every fresh install already has a default identity named
+/// `main` (confirmed via `openclaw agents list` → `main (default)`,
+/// workspace `~/.openclaw/workspace`, with zero onboarding run), so the
+/// default template hardcodes `--agent main`. The instruction is delivered via
+/// `-m/--message` as an ARGUMENT. Running
+/// `openclaw agent --local --agent main --message {prompt}` reaches a real
+/// `ProviderAuthError: No API key found for provider "openai"` — past argument
+/// parsing, proving the invocation is correct; full completion needs the
+/// user's own provider credentials (`openclaw agents add`/`openclaw
+/// configure`). No `--json`: its `--json` schema is
+/// `{payloads, meta, deliveryStatus}`, not the Claude-shaped events
+/// `parseAgentOutput.ts` recognizes, so plain stdout text is the safer default
+/// (same reasoning as Kimi's `text` choice) — and since the run never got past
+/// the auth error, no successful `--json` payload could be captured to
+/// consider parser support anyway.
+///
+/// Hermes Agent's flags are LIVE-VERIFIED against `hermes` v0.19.0 (installed
+/// via the official installer,
+/// `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+/// -s -- --skip-setup --skip-browser --non-interactive`). `-z/--oneshot
+/// PROMPT` is documented as the purest headless mode: "send a single prompt
+/// and print ONLY the final response text to stdout... approvals are
+/// auto-bypassed" — so `prompt_via` is `Arg`. `--yolo` (bypass dangerous-
+/// command approval prompts) was checked for the same `-p`+`--auto` trap Kimi
+/// hit: unlike Kimi, `-z {prompt} --yolo` and `-z {prompt}` alone both reach
+/// the IDENTICAL clean error (`No inference provider configured...`) —
+/// confirming no usage-error conflict — so `--yolo` is kept for
+/// defense-in-depth parity with Claude's `acceptEdits` (git remains the safety
+/// net). `-z` already respects the process's `{cwd}` (loads `AGENTS.md` from
+/// the CWD as documented), so no `{cwd}` token is needed in the template.
+/// Output is plain final-response text by design (no JSON/stream mode exists
+/// for `-z`), a clean fit for the raw-output fallback.
 pub fn default_cli_template(cli_type: AgentCliType) -> (String, PromptDelivery) {
     match cli_type {
         AgentCliType::Claude => (
@@ -219,9 +261,17 @@ pub fn default_cli_template(cli_type: AgentCliType) -> (String, PromptDelivery) 
         // Codex CLI: `codex exec` is the non-interactive mode; `--json` streams
         // JSONL. The prompt is passed as the trailing positional arg.
         AgentCliType::Codex => ("exec --json {prompt}".to_string(), PromptDelivery::Arg),
-        // Best-effort placeholders until the binaries are available to verify.
-        AgentCliType::Openclaw => ("run {prompt}".to_string(), PromptDelivery::Arg),
-        AgentCliType::Hermes => ("run {prompt}".to_string(), PromptDelivery::Arg),
+        // See the doc comment above: live-verified against openclaw 2026.7.1-2.
+        // `--agent main` addresses the default identity every fresh install
+        // already has; no `--json` (its schema doesn't match parseAgentOutput.ts).
+        AgentCliType::Openclaw => (
+            "agent --local --agent main --message {prompt}".to_string(),
+            PromptDelivery::Arg,
+        ),
+        // See the doc comment above: live-verified against hermes v0.19.0.
+        // `-z` is the documented purest one-shot mode (final text only,
+        // approvals auto-bypassed); `--yolo` verified to NOT conflict with it.
+        AgentCliType::Hermes => ("-z {prompt} --yolo".to_string(), PromptDelivery::Arg),
         // See the doc comment above: no --yolo/--auto — combining either with
         // -p is a hard CLI usage error, live-verified against kimi-code 0.28.1.
         AgentCliType::Kimi => (
@@ -2229,6 +2279,39 @@ mod tests {
         assert!(!template.contains("--auto"));
         assert_eq!(via, PromptDelivery::Arg);
         assert_eq!(default_cli_binary_name(AgentCliType::Kimi), Some("kimi"));
+    }
+
+    #[test]
+    fn openclaw_default_template_matches_live_verified_flags() {
+        // Live-verified against openclaw 2026.7.1-2: `openclaw agent --help`
+        // has no `--dir`/`--cwd` flag — it addresses a named `--agent`
+        // identity, and every fresh install already has one named `main`
+        // (confirmed via `openclaw agents list`). `--local` runs the embedded
+        // agent without a Gateway process; `-m/--message` is the prompt arg.
+        let (template, via) = default_cli_template(AgentCliType::Openclaw);
+        assert_eq!(template, "agent --local --agent main --message {prompt}");
+        assert_eq!(via, PromptDelivery::Arg);
+        assert_eq!(
+            default_cli_binary_name(AgentCliType::Openclaw),
+            Some("openclaw")
+        );
+    }
+
+    #[test]
+    fn hermes_default_template_matches_live_verified_flags() {
+        // Live-verified against hermes v0.19.0: `-z/--oneshot` is the
+        // documented purest headless mode (final response text only,
+        // approvals auto-bypassed). `--yolo` was checked for the same
+        // `-p`+`--auto` trap Kimi hit and found NOT to conflict: `-z {prompt}
+        // --yolo` reaches the identical clean auth/config error as `-z
+        // {prompt}` alone.
+        let (template, via) = default_cli_template(AgentCliType::Hermes);
+        assert_eq!(template, "-z {prompt} --yolo");
+        assert_eq!(via, PromptDelivery::Arg);
+        assert_eq!(
+            default_cli_binary_name(AgentCliType::Hermes),
+            Some("hermes")
+        );
     }
 
     #[test]

--- a/verification/openclaw-hermes-cli-agents/RESULTS.md
+++ b/verification/openclaw-hermes-cli-agents/RESULTS.md
@@ -1,0 +1,318 @@
+# OpenClaw + Hermes CLI agent verification results
+
+Branch `feat/openclaw-hermes-agents`. `AgentCliType::Openclaw` and
+`AgentCliType::Hermes` already existed as first-class enum variants, but their
+`default_cli_template`/`prompt_via`/`binary_name` were written BEST-EFFORT and
+never installed or verified — this PR does for them exactly what PR #50 did
+for Kimi: install the real binary, drive its flags until a usage error becomes
+an auth/config error, and fix the defaults to the verified invocation.
+
+Platform tested: macOS (Intel, Darwin 23.5.0).
+
+## OpenClaw
+
+### What it actually is (important context)
+
+OpenClaw (`https://github.com/openclaw/openclaw`, `openclaw.ai`) is **not**
+shaped like Claude/Codex/Kimi. Those are one-shot "run in a project directory"
+coding CLIs. OpenClaw is a persistent personal-assistant **gateway/daemon**
+that bridges an LLM to messaging channels (WhatsApp/Telegram/Slack/Discord/…)
+via a background "heartbeat" process, plus a plugin/skills marketplace
+(ClawHub). It has no per-run `--cwd`/`--dir` flag anywhere in its CLI surface.
+
+### Install — live-verified
+
+```
+$ npm install -g openclaw@latest
+npm warn EBADENGINE Unsupported engine {
+npm warn EBADENGINE   package: 'openclaw@2026.7.1-2',
+npm warn EBADENGINE   required: { node: '>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0' },
+npm warn EBADENGINE   current: { node: 'v24.2.0', npm: '11.3.0' }
+npm warn EBADENGINE }
+added 309 packages in 19s
+```
+
+npm installs it anyway despite the engine warning, but the binary then
+**hard-refuses to run at all**:
+
+```
+$ openclaw --version
+openclaw: Node.js >=22.22.3 <23, >=24.15.0 <25, or >=25.9.0 is required (current: v24.2.0).
+If you use nvm, run:
+  nvm install 24
+  nvm use 24
+  nvm alias default 24
+```
+
+This Node-version gate is a real, live-discovered gotcha (not documented
+anywhere we found) — it would silently look like a broken install to any user
+whose Node is a hair outside the supported range. It's an install
+prerequisite, not something the command template can work around, so it's
+recorded here rather than encoded in code. Installed `node@24` via Homebrew
+(`brew install node@24`, kept keg-only/unlinked so it doesn't disturb the
+system default Node) and re-ran everything with
+`PATH="/usr/local/opt/node@24/bin:$PATH"` (Node v24.18.0):
+
+```
+$ openclaw --version
+OpenClaw 2026.7.1-2 (0790d9f)
+```
+
+### `openclaw --help` — finding the headless equivalent
+
+The full command surface is large (daemon/channels/plugins/skills/etc.). The
+one command that matches "run one turn non-interactively" is:
+
+```
+agent    Run an agent turn via the Gateway (use --local for embedded)
+```
+
+```
+$ openclaw agent --help
+Usage: openclaw agent [options]
+
+Run an agent turn via the Gateway (use --local for embedded)
+
+Options:
+  --agent <id>               Agent id (overrides routing bindings)
+  --deliver                  Send the agent's reply back to the selected channel (default: false)
+  --json                     Output result as JSON (default: false)
+  --local                    Run the embedded agent locally (requires model provider API keys in your shell) (default: false)
+  -m, --message <text>       Message body for the agent
+  ...
+```
+
+`--local` is the analog of Claude's `-p` / Codex's `exec` / Kimi's `-p`: it
+runs the embedded agent directly with no Gateway process required. Crucially,
+there is **no `--cwd`/`--dir`/`--workspace` flag on `agent` at all** — instead
+it addresses a **named agent identity** via `--agent <id>`, and each identity
+has its own fixed workspace configured separately (`openclaw agents add
+--workspace <dir>`).
+
+### Does a fresh install have a usable default identity?
+
+Yes — confirmed with zero onboarding run:
+
+```
+$ openclaw agents list
+Agents:
+- main (default)
+  Workspace: ~/.openclaw/workspace
+  Agent dir: ~/.openclaw/agents/main/agent
+  Routing rules: 0
+  Routing: default (no explicit rules)
+```
+
+So the default template hardcodes `--agent main` — it is the tool's own
+default identity, not a guess.
+
+### Driving `openclaw agent --local` for real
+
+```
+$ openclaw agent --local --agent main --message "say hello"
+Error: Pass --to <E.164>, --session-key, --session-id, or --agent to choose a session
+```
+
+(That was hit once _without_ `--agent`, confirming the flag is mandatory —
+exactly the reason `--agent main` belongs in the default template.) With
+`--agent main` supplied:
+
+```
+$ openclaw agent --local --agent main --message "say hello" --json
+[diagnostic] lane task error: lane=main durationMs=1492 error="ProviderAuthError: No API key found for provider "openai". Auth store: /Users/avijitsarkar/.openclaw/agents/main/agent/openclaw-agent.sqlite (agentDir: /Users/avijitsarkar/.openclaw/agents/main/agent). Configure auth for this agent (openclaw agents add <id>) or copy only portable static auth profiles from the main agentDir."
+[diagnostic] lane task error: lane=session:agent:main:main durationMs=1512 error="ProviderAuthError: ..."
+[model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai/gpt-5.5 candidate=openai/gpt-5.5 reason=auth next=none detail=...
+FailoverError: No API key found for provider "openai". ... | missing-provider-auth
+```
+
+This is the exact proof the task asked for: **no usage error** ("Pass --to
+...", "unknown option", etc.) — the CLI parsed `--local --agent main
+--message ...` fine and failed only on `ProviderAuthError` /
+`FailoverError: missing-provider-auth`, which requires the user's own model
+provider credentials (`openclaw agents add`/`openclaw configure`) to go
+further. Verified stdout/stderr separately (`1>file 2>file`): stdout was
+empty and all of the above went to stderr, with the same result whether or
+not `--json` was passed (the run fails before any output-formatting stage is
+reached either way).
+
+**Verified default template:** `agent --local --agent main --message
+{prompt}` with `prompt_via = Arg`.
+
+### Output-format decision: no `--json`
+
+Per `docs.openclaw.ai/cli/agent`, `--json` (with `--deliver`) returns
+`{payloads, meta, deliveryStatus}` — not the Claude-shaped
+`{"type": "system"|"assistant"|"user"|"result"}` events
+`parseAgentOutput.ts` recognizes. No successful run was possible (no API key)
+to capture real `--json` output for comparison anyway. Same call as Kimi:
+default to plain stdout text, which the raw-output fallback renders cleanly.
+
+### What still needs the user
+
+- **A model provider API key/credential** configured for the `main` agent
+  (`openclaw agents add`/`openclaw configure`, or an env var such as
+  `OPENAI_API_KEY`) — this agent cannot fabricate one. Once configured, a full
+  run + Agent Runs panel screenshot is the natural follow-up.
+- **Node version**: OpenClaw requires Node `>=22.22.3<23`, `>=24.15.0<25`, or
+  `>=25.9.0`. A user on an older/mismatched Node (as this machine's system
+  Node, v24.2.0, was) will see `openclaw` hard-refuse to start with an
+  actionable nvm hint — worth knowing before reporting a "broken install."
+- **Per-project workspace mismatch (architectural, not a bug in this PR)**:
+  OpenFlow spawns the CLI with `current_dir` set to the configured
+  `project_path`/`{cwd}`, but OpenClaw's `--agent main` identity has its own
+  fixed workspace (`~/.openclaw/workspace`) independent of the spawn cwd —
+  `openclaw agent` has no flag to override it per run. Multi-project use would
+  need per-project OpenClaw agent identities (`openclaw agents add --workspace
+  <dir>`) configured by the user; that's beyond what a CLI-agent-type default
+  template can express, so it's called out here rather than silently assumed.
+
+**Release-readiness verdict: template correct, verified past argument parsing
+into an auth error — user-verification-pending** (needs the user's own
+provider credentials to confirm a full run, same bar as Kimi).
+
+## Hermes Agent
+
+### Install — live-verified
+
+```
+$ curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- \
+    --skip-setup --skip-browser --non-interactive
+...
+✓ Installation Complete!
+Config:    /Users/avijitsarkar/.hermes/config.yaml
+API Keys:  /Users/avijitsarkar/.hermes/.env
+Code:      /Users/avijitsarkar/.hermes/hermes-agent
+Commands:
+   hermes              Start chatting
+   ...
+```
+
+```
+$ hermes --version
+Hermes Agent v0.19.0 (2026.7.20) · upstream cbc1054e
+Install directory: /Users/avijitsarkar/.hermes/hermes-agent
+Install method: git
+Python: 3.11.7
+```
+
+Binary lands at `~/.local/bin/hermes` (confirmed with `ls -la`) — already
+covered by the existing `.local/bin` entry in `baseline_bin_dirs`, so **no
+baseline-dir change was needed** for Hermes.
+
+### `hermes --help` — finding the headless equivalent
+
+```
+  -z PROMPT, --oneshot PROMPT
+                        One-shot mode: send a single prompt and print ONLY the
+                        final response text to stdout. No banner, no spinner,
+                        no tool previews, no session_id line. Tools, memory,
+                        rules, and AGENTS.md in the CWD are loaded as normal;
+                        approvals are auto-bypassed. Intended for scripts / pipes.
+  ...
+  --yolo                Bypass all dangerous command approval prompts (use at
+                        your own risk)
+```
+
+`-z`/`--oneshot` is documented, in Hermes's own words, as the purest headless
+mode — and it already loads `AGENTS.md`/rules from the process's **current
+working directory**, so no `{cwd}` token is needed in the template (matches
+how `current_dir` is already set for every CLI-agent spawn).
+
+### Checking for the Kimi-style trap: does `--yolo` conflict with `-z`?
+
+```
+$ hermes -z "say hello"
+hermes -z: agent failed: No inference provider configured. Run 'hermes model' to choose a
+provider and model, or set an API key (OPENROUTER_API_KEY, OPENAI_API_KEY, etc.) in
+~/.hermes/.env.
+
+$ hermes -z "say hello" --yolo
+hermes -z: agent failed: No inference provider configured. Run 'hermes model' to choose a
+provider and model, or set an API key (OPENROUTER_API_KEY, OPENAI_API_KEY, etc.) in
+~/.hermes/.env.
+```
+
+Unlike Kimi's `-p`/`--auto`/`--yolo` (hard usage error), Hermes's `-z` and
+`--yolo` combine cleanly — both reach the **identical** clean
+config/auth error (not a usage error), proving the invocation is correct. Since
+`-z` already auto-bypasses tool-call approvals per its own docs, `--yolo` is
+redundant defense-in-depth (matching Claude's `acceptEdits` in spirit — git
+remains the safety net) rather than load-bearing, and it is verified safe to
+keep.
+
+**Verified default template:** `-z {prompt} --yolo` with `prompt_via = Arg`.
+
+### Output-format decision: none needed
+
+`-z` has no JSON/stream-json variant — its entire contract is "print ONLY the
+final response text to stdout." That is already the plain-text shape the
+raw-output fallback in `parseAgentOutput.ts` renders cleanly, so there is no
+format flag to choose (unlike Kimi/OpenClaw, which both had to actively opt
+out of a JSON mode).
+
+### What still needs the user
+
+- **A model provider credential** (`hermes model`, `hermes setup`, or an env
+  var such as `OPENROUTER_API_KEY`/`OPENAI_API_KEY` in `~/.hermes/.env`) —
+  cannot be fabricated by this agent. Once configured, a full run + Agent Runs
+  panel screenshot is the natural follow-up, but is not required to trust this
+  fix: the flag-parsing proof above (clean config error, not a usage error) is
+  the evidence the task asked for.
+
+**Release-readiness verdict: template correct, verified past argument parsing
+into a config/auth error — user-verification-pending** (needs the user's own
+provider credentials to confirm a full run).
+
+## `{prompt}` single-argv-element substitution — regression-tested for both
+
+`build_argv` (`src-tauri/src/managers/agent_run.rs`) tokenizes the template
+first, then substitutes `{prompt}` within the already-split token — so a
+multi-word instruction never gets re-split. Added agent-specific regression
+tests exercising the real default templates end to end:
+
+```rust
+build_argv("agent --local --agent main --message {prompt}", "/tmp/proj", "list all the files", PromptDelivery::Arg)
+  == vec!["agent", "--local", "--agent", "main", "--message", "list all the files"]
+
+build_argv("-z {prompt} --yolo", "/tmp/proj", "list all the files", PromptDelivery::Arg)
+  == vec!["-z", "list all the files", "--yolo"]
+```
+
+## Binary detection
+
+- **OpenClaw**: added `.openclaw/bin` to the unix baseline dir list in
+  `baseline_bin_dirs` — OpenClaw's `install-cli.sh` variant defaults to
+  installing at `<prefix>/bin/openclaw` with prefix `~/.openclaw`, which a
+  GUI-launched app's stripped PATH would miss (same class of bug as the
+  pre-existing Claude/Codex/Kimi detection fixes). The plain `npm install -g`
+  path used for this PR's live verification instead lands in npm's global bin
+  dir, already covered by existing entries.
+- **Hermes**: no change needed. Its installer symlinks to `~/.local/bin/hermes`,
+  which was already in the baseline list (added for Claude Code's native
+  install).
+
+Both additions/no-ops are regression-tested in
+`baseline_bin_dirs_includes_home_and_static_dirs`.
+
+## Gates (all green)
+
+| Gate                   | Result                                                                                                                                                                                                    |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cargo test` (`--lib`) | 312 passed, 0 failed (was 308; +4 new tests)                                                                                                                                                              |
+| `cargo build`          | clean (only pre-existing unrelated warnings)                                                                                                                                                              |
+| `bunx tsc --noEmit`    | clean                                                                                                                                                                                                     |
+| `bun run lint`         | 0 errors (1 pre-existing unrelated warning in `devAutomation.ts`)                                                                                                                                         |
+| `bun run format`       | clean (only reformatted this PR's own new Rust code)                                                                                                                                                      |
+| `bun run build`        | success (2815 modules)                                                                                                                                                                                    |
+| `src/bindings.ts`      | unchanged — no type-surface change (`AgentCliType`'s variants and shapes are untouched; only the two variants' default values/docs changed), confirmed via `cargo run -- --list-models` producing no diff |
+
+## Regression — Claude/Codex/Kimi/Custom unchanged
+
+`default_cli_template`/`default_cli_binary_name` for `Claude`, `Codex`,
+`Kimi`, `Custom` are untouched; their existing tests
+(`claude_default_template_matches_verified_flags`,
+`kimi_default_template_matches_live_verified_flags`, the `build_argv_*`
+stdin/arg tests, `cli_agent_round_trips_through_serde`) all still pass
+unmodified. `CliAgentCard.tsx`'s `CLI_TYPES` list and the
+`settings.agents.card.cli.agentType.options.{openclaw,hermes}` i18n labels
+("OpenClaw", "Hermes") were already correct and needed no change.


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/avijeett007/openflow/issues) and [pull requests](https://github.com/avijeett007/openflow/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/avijeett007/openflow/blob/main/CONTRIBUTING.md)

## Human Written Description

<!-- TODO(maintainer): please replace this with 2-3 sentences in your own words — what problem you noticed and why this matters to you. -->

## Related Issues

Fixes #

## Testing

`AgentCliType::Openclaw` and `::Hermes` already existed as first-class agent types, but their `default_cli_template`/`prompt_via` were best-effort placeholders (`"run {prompt}"`) written before either binary was installed or run — a blocker since the CLI-agent feature shipped. This PR does for both of them exactly what PR #50 did for Kimi: install the real CLI, drive its flags for real, and fix the defaults to the verified invocation.

### OpenClaw

Installed the real `openclaw` CLI (`npm install -g openclaw@latest`, v2026.7.1-2). It needed Node `>=24.15.0<25` — the system Node here was v24.2.0, and `openclaw` hard-refuses to even print `--version` with an actionable nvm hint. Installed a keg-only Homebrew `node@24` (v24.18.0) alongside the system Node to unblock verification without disturbing anything else.

OpenClaw turned out to be architecturally different from Claude/Codex/Kimi: it's a persistent messaging-channel gateway/daemon (WhatsApp/Telegram/Slack/…), not a one-shot "run in a project directory" coding CLI. `openclaw agent --help` has no `--cwd`/`--dir` flag at all — instead `--local` runs the embedded agent without a Gateway process, addressing a named identity via `--agent <id>`. A fresh install already has a default identity named `main` (confirmed via `openclaw agents list`, zero onboarding run), so the default template hardcodes it:

```
$ openclaw agent --local --agent main --message "say hello" --json
[diagnostic] lane task error: lane=main durationMs=1492 error="ProviderAuthError: No API key found for provider "openai". ..."
FailoverError: No API key found for provider "openai". ... | missing-provider-auth
```

No usage error — the CLI parsed the flags fine and failed only on a real `ProviderAuthError`, proving the invocation is correct. **Verified default:** `agent --local --agent main --message {prompt}`, `prompt_via = Arg`. Added `.openclaw/bin` to `baseline_bin_dirs` (one of OpenClaw's own install-prefix locations, not on a GUI-launched app's stripped PATH).

### Hermes

Installed the real `hermes` CLI (official installer, `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-setup --skip-browser --non-interactive`, v0.19.0). `-z`/`--oneshot PROMPT` is documented, in Hermes's own words, as the purest headless mode ("print ONLY the final response text to stdout... approvals are auto-bypassed") and already respects the process's CWD for `AGENTS.md`/rules — no `{cwd}` token needed.

Checked for the same `-p`+`--auto` incompatibility Kimi hit with `--yolo`:

```
$ hermes -z "say hello"
hermes -z: agent failed: No inference provider configured. ...

$ hermes -z "say hello" --yolo
hermes -z: agent failed: No inference provider configured. ...
```

Identical clean config error either way — no conflict, unlike Kimi. **Verified default:** `-z {prompt} --yolo`, `prompt_via = Arg`. Binary lands at `~/.local/bin/hermes`, already covered by an existing `baseline_bin_dirs` entry — no dir change needed.

Both agents reach a real auth/config error (not a usage error) and stop there honestly — see the honesty gate below.

**Gates:** `cargo test` 312 passed (was 308; +4 new: 2 verified-defaults tests + 2 `{prompt}`-single-arg regression tests), `cargo build` clean, `bunx tsc --noEmit` clean, `bun run lint` 0 errors (1 pre-existing unrelated warning), `bun run format` clean, `bun run build` success (2815 modules). `src/bindings.ts` unchanged — no type-surface change (only the two variants' default values/doc comments changed, not `AgentCliType` itself); confirmed via `cargo run -- --list-models` producing no diff. Claude/Codex/Kimi/Custom defaults and existing tests are untouched (regression-verified). `CliAgentCard.tsx`'s type dropdown and the "OpenClaw"/"Hermes" i18n labels were already correct.

Full verbatim transcripts, the Node-version gotcha, and the output-format reasoning: `verification/openclaw-hermes-cli-agents/RESULTS.md`.

### Honesty gate — release-readiness per agent

| Agent | Installed? | Auth done? | Flag-parsing verified? | Full run done? | Verdict |
| --- | --- | --- | --- | --- | --- |
| OpenClaw | Yes (npm, real binary, real Node-version fix) | No — needs the user's own model-provider credential | Yes — reaches `ProviderAuthError`, not a usage error | No | **Template correct, user-verification-pending** |
| Hermes | Yes (official installer, real binary) | No — needs the user's own model-provider credential | Yes — reaches a clean config error, not a usage error | No | **Template correct, user-verification-pending** |

Neither agent is a live full-run "release-ready" yet — both need the user's own provider credentials (OpenAI/OpenRouter/etc.) to go further, and none were fabricated. The templates themselves are proven correct by reaching an auth/config error instead of a usage error, the same bar Kimi's PR set.

## Screenshots/Videos (if applicable)

Not applicable — no authenticated run was possible for either agent (both need the user's own model-provider credentials). Verbatim terminal transcripts proving both CLI invocations are correct are in `verification/openclaw-hermes-cli-agents/RESULTS.md`.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Sonnet 5)
- How extensively: Full implementation — studied the Kimi CLI-agent precedent (PR #50), installed and live-tested the real OpenClaw and Hermes CLI binaries to verify their invocations (including discovering OpenClaw's Node-version gate and confirming Hermes's `-z`+`--yolo` has no Kimi-style conflict), implemented the Rust changes, added regression tests, and wrote the verification doc.
