### PR TITLE
fix: bump transcribe-cpp 0.1.0 → 0.1.3 (Metal capability gate)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7148,9 +7148,9 @@ dependencies = [
 
 [[package]]
 name = "transcribe-cpp"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b4a8ff896f7099716286aabaf9df0f78f26f7e3707d33dcd1c82a2ca0563b6"
+checksum = "4c3c4d6136eeccf56cfe8a6669e2d63770d1ef051c7cafd2cb9226218c66cded"
 dependencies = [
  "log",
  "thiserror 2.0.18",
@@ -7159,9 +7159,9 @@ dependencies = [
 
 [[package]]
 name = "transcribe-cpp-sys"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06fff0397caf8032bfa911209be2ac542f5d52440832c24a6ffdf47b3788911"
+checksum = "278fd6a6da4d9d8d5f2716bd6761a76ea55c129fda6ba57856b80249a8570ed4"
 dependencies = [
  "cmake",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -84,7 +84,7 @@ sha2 = "0.10"
 # transcribe-rs is now ONNX-only (Parakeet, Moonshine, SenseVoice, GigaAM,
 # Canary, Cohere). Per-platform backend features are added in the target tables.
 transcribe-rs = { version = "0.3.8", features = ["onnx"] }
-transcribe-cpp = { version = "0.1.0", default-features = false }
+transcribe-cpp = { version = "0.1.3", default-features = false }
 handy-keys = "0.3.0"
 ferrous-opencc = "0.2.3"
 clap = { version = "4", features = ["derive"] }
@@ -159,14 +159,14 @@ winreg = "0.55"
 # toolchain dependency and produces a working unsigned installer; STT runs on
 # CPU (Parakeet/Whisper). GPU acceleration on Windows is a later optimization.
 [target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies]
-transcribe-cpp = { version = "0.1.0", default-features = false }
+transcribe-cpp = { version = "0.1.3", default-features = false }
 
 [target.'cfg(all(windows, target_arch = "aarch64"))'.dependencies]
-transcribe-cpp = { version = "0.1.0", default-features = false }
+transcribe-cpp = { version = "0.1.3", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
-transcribe-cpp = { version = "0.1.0", default-features = false, features = ["metal"] }
+transcribe-cpp = { version = "0.1.3", default-features = false, features = ["metal"] }
 # Frontmost-app detection via NSWorkspace (no Accessibility grant required),
 # replacing the osascript/System Events path that errored with -1719.
 objc2 = "0.6"
@@ -202,7 +202,7 @@ bzip2 = "0.4"
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk-layer-shell = { version = "0.8", features = ["v0_6"] }
 gtk = "0.18"
-transcribe-cpp = { version = "0.1.0", default-features = false, features = [
+transcribe-cpp = { version = "0.1.3", default-features = false, features = [
   "dynamic-backends",
   "vulkan",
 ] }

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -1780,6 +1780,15 @@ fn resolve_device_index(index: usize) -> Result<(Backend, i32)> {
 /// which is exactly what silently broke hands-free. CPU there runs ~7x realtime
 /// and works end-to-end. Apple-silicon Macs keep Metal via `Auto`, and an
 /// explicit `Gpu`/Metal selection is still honored below.
+///
+/// As of transcribe-cpp 0.1.3, the library itself gates Metal on an Apple7
+/// simdgroup-matrix capability check and falls back to CPU internally for
+/// unsupported Metal devices (cjpais/Handy#1626) — most Intel Macs (which
+/// expose only Intel iGPU / AMD dGPU Metal devices) should now be caught by
+/// that gate before ever reaching a failing load. This `#[cfg]` override is
+/// kept anyway as a belt-and-braces second layer: it is cheap, and it still
+/// protects any Intel-Mac configuration the upstream capability probe
+/// doesn't catch (or a future transcribe-cpp regression in that check).
 fn select_transcribe_backend(setting: TranscribeAcceleratorSetting) -> Backend {
     match setting {
         TranscribeAcceleratorSetting::Cpu => Backend::Cpu,


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched [existing issues](https://github.com/avijeett007/openflow/issues) and [pull requests](https://github.com/avijeett007/openflow/pulls) (including closed ones) to ensure this isn't a duplicate
- [x] I have read [CONTRIBUTING.md](https://github.com/avijeett007/openflow/blob/main/CONTRIBUTING.md)

## Human Written Description

<!-- TODO(human): this PR was prepared by an AI coding agent (see AI Assistance
below) at the maintainer's direction. Please replace this placeholder with your
own 2-3 sentences before merging, per AGENTS.md's instruction not to invent a
human contributor's voice. -->

TODO — maintainer to fill in.

## Related Issues

Not tied to a local OpenFlow issue. Fixes the class of bug tracked upstream at
cjpais/Handy#1626 ("model loads at startup but hangs/crashes/fails on load" on
unsupported Metal devices).

## Testing

Bumped `transcribe-cpp` (and its `-sys` crate) from 0.1.0 → 0.1.3 in
`src-tauri/Cargo.toml` (all five per-platform dependency blocks) and
regenerated `src-tauri/Cargo.lock` via
`cargo update -p transcribe-cpp --precise 0.1.3`.

- Compared against upstream Handy's own 0.1.0→0.1.1→0.1.2→0.1.3 bumps
  (PRs #1589, #1634, #1664 in cjpais/Handy): each hop was a pure
  Cargo.toml/lock version bump with **no accompanying Rust source changes**
  (the 0.1.3 commit only touched CI/BUILD.md docs for an unrelated Windows
  MAX_PATH fix). So no call-site/API adjustments were required on the
  OpenFlow side.
- Confirmed 0.1.3 is also the current `max_version`/`newest_version` on
  crates.io (matches what upstream pinned).
- `cargo build` in `src-tauri` succeeds on Intel macOS
  (`x86_64-apple-darwin`, with `ORT_LIB_LOCATION`/`ORT_PREFER_DYNAMIC_LINK`
  per BUILD.md) — `transcribe-cpp v0.1.3` / `transcribe-cpp-sys v0.1.3`
  compile cleanly, `openflow` lib+bin finish with only 2 pre-existing,
  unrelated warnings (`meeting/capture.rs` unnecessary `unsafe`,
  `backends/stt_http.rs` dead field).
- `cargo test` in `src-tauri`: **312 passed, 0 failed, 0 ignored**.
- `cargo fmt -- --check`: clean, no diff.

**Non-breaking:** this is a dependency-version-only change plus a doc
comment. The fork's existing app-level Intel-Mac override in
`select_transcribe_backend()` (`src-tauri/src/managers/transcription.rs`,
forcing `Backend::Cpu` instead of `Backend::Auto` on `x86_64` macOS) is
**kept, unchanged in behavior** — only its doc comment was extended to
note that transcribe-cpp now also gates Metal capability at the library
level as of 0.1.3, so the app-level override is now a second,
belt-and-braces layer rather than the sole protection. No settings,
commands, or other call sites changed.

Not build-verified on Windows/Linux/Apple-silicon macOS in this PR (no
access to those runners here); CI should cover them.

## Screenshots/Videos (if applicable)

N/A — dependency version bump + comment, no UI change.

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Anthropic), directed by the repo owner
- How extensively: AI performed the full change — researched upstream
  Handy's transcribe-cpp bump history, verified crates.io's latest 0.1.x,
  updated `Cargo.toml`/`Cargo.lock`, extended the doc comment on
  `select_transcribe_backend()`, and ran `cargo build`/`cargo test`/
  `cargo fmt --check` to verify.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
