### PR TITLE
fix: panic-safe model reload + hang-proof dictation pipeline

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1843,7 +1843,23 @@ impl ShortcutAction for TranscribeAction {
                             // surfaced instead — the worker may still hold the engine,
                             // so a batch fallback would contend with it.
                             Ok(Some(text)) if !text.trim().is_empty() => Ok(text),
-                            Ok(_) => tm.transcribe(samples),
+                            // Run the (blocking, CPU/GPU-bound) batch transcription
+                            // on a blocking thread so it never parks a Tokio worker
+                            // — a synchronous call here previously blocked the async
+                            // runtime for the whole transcription.
+                            Ok(_) => {
+                                let tm_batch = Arc::clone(&tm);
+                                match tauri::async_runtime::spawn_blocking(move || {
+                                    tm_batch.transcribe(samples)
+                                })
+                                .await
+                                {
+                                    Ok(res) => res,
+                                    Err(e) => {
+                                        Err(anyhow::anyhow!("Transcription task panicked: {e}"))
+                                    }
+                                }
+                            }
                             Err(err) => Err(err),
                         }
                     };

--- a/src-tauri/src/audio_toolkit/audio/recorder.rs
+++ b/src-tauri/src/audio_toolkit/audio/recorder.rs
@@ -332,7 +332,13 @@ impl AudioRecorder {
         if let Some(tx) = &self.cmd_tx {
             tx.send(Cmd::Stop(resp_tx))?;
         }
-        Ok(resp_rx.recv()?) // wait for the samples
+        // Bounded wait: if the worker never replies (wedged), fail instead of
+        // blocking the caller forever. 10s is far beyond a normal stop.
+        resp_rx.recv_timeout(Duration::from_secs(10)).map_err(|e| {
+            Box::new(Error::other(format!(
+                "Timed out waiting for recorder to return samples: {e}"
+            ))) as Box<dyn std::error::Error>
+        })
     }
 
     /// Begin always-open wake-word monitoring. Orthogonal to `start()`: a manual

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -37,6 +37,23 @@ use transcribe_rs::{
 
 const STREAM_PERF_LOG_INTERVAL: Duration = Duration::from_secs(5);
 const STREAM_FINALIZE_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
+/// Maximum time a transcribe/stream call blocks waiting for an in-progress model
+/// load before giving up. Loads can legitimately take tens of seconds on slow
+/// disks or large GGUFs, so the cap is generous — its only job is to make sure a
+/// wedged loader (e.g. a panicked native loader) can never block a caller here
+/// forever, which previously hung the whole app.
+const MODEL_LOAD_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Extract a human-readable message from a `catch_unwind` panic payload.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ModelStateEvent {
@@ -688,33 +705,66 @@ impl TranscriptionManager {
         Ok(())
     }
 
+    /// Emit a `loading_failed` model-state event so the frontend can toast the
+    /// underlying error. Used by failure paths that bypass `load_model`'s own
+    /// emit (notably a panicked native loader).
+    fn emit_load_failed(&self, model_id: &str, error: &str) {
+        let model_name = self.model_manager.get_model_info(model_id).map(|m| m.name);
+        let _ = self.app_handle.emit(
+            "model-state-changed",
+            ModelStateEvent {
+                event_type: "loading_failed".to_string(),
+                model_id: Some(model_id.to_string()),
+                model_name,
+                error: Some(error.to_string()),
+            },
+        );
+    }
+
     /// Kicks off the model loading in a background thread if it's not already loaded
     pub fn initiate_model_load(&self) {
-        let mut is_loading = self.is_loading.lock().unwrap();
-        if *is_loading {
+        // Atomically claim the loading slot. The returned RAII guard clears
+        // `is_loading` and wakes condvar waiters on drop — including when the
+        // spawned thread panics inside a native loader — so a failed load can
+        // never leave the flag stuck true (which used to permanently wedge
+        // reloads and hang every waiting transcribe/stream call).
+        let Some(guard) = self.try_start_loading() else {
             return;
-        }
+        };
 
         let reload_pending = self.reload_model_on_next_use.load(Ordering::Acquire);
         if !reload_pending && self.is_model_loaded() {
-            return;
+            return; // `guard` drops here, releasing the slot.
         }
 
-        *is_loading = true;
         let self_clone = self.clone();
         thread::spawn(move || {
+            // Move the guard into the thread so the slot is released on every
+            // exit path (return, error, or panic during unwind).
+            let _guard = guard;
             if reload_pending {
                 self_clone
                     .reload_model_on_next_use
                     .store(false, Ordering::Release);
             }
             let settings = get_settings(&self_clone.app_handle);
-            if let Err(e) = self_clone.load_model(&settings.selected_model) {
-                error!("Failed to load model: {}", e);
+            let model_id = settings.selected_model.clone();
+            // Native whisper/GGML/Metal/ONNX loaders can panic (not just Err);
+            // catch it so we can log the payload and surface a UI toast instead
+            // of silently losing the failure to a dead thread.
+            match catch_unwind(AssertUnwindSafe(|| self_clone.load_model(&model_id))) {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    // load_model already emitted `loading_failed` for this path.
+                    error!("Failed to load model: {}", e);
+                }
+                Err(panic_payload) => {
+                    let msg = panic_message(panic_payload.as_ref());
+                    error!("Model load panicked: {}", msg);
+                    self_clone
+                        .emit_load_failed(&model_id, &format!("Model load panicked: {}", msg));
+                }
             }
-            let mut is_loading = self_clone.is_loading.lock().unwrap();
-            *is_loading = false;
-            self_clone.loading_condvar.notify_all();
         });
     }
 
@@ -789,11 +839,38 @@ impl TranscriptionManager {
         };
 
         // Wait for any in-progress model load to finish (start_stream races the
-        // background load kicked off when recording starts).
+        // background load kicked off when recording starts) — bounded so a
+        // wedged loader can't strand this worker (and its held router/lease)
+        // forever. On timeout, fall back to batch transcription.
         {
+            let deadline = Instant::now() + MODEL_LOAD_WAIT_TIMEOUT;
             let mut is_loading = self.is_loading.lock().unwrap();
+            let mut timed_out = false;
             while *is_loading {
-                is_loading = self.loading_condvar.wait(is_loading).unwrap();
+                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                    timed_out = true;
+                    break;
+                };
+                let (guard, wait_res) = self
+                    .loading_condvar
+                    .wait_timeout(is_loading, remaining)
+                    .unwrap();
+                is_loading = guard;
+                if wait_res.timed_out() && *is_loading {
+                    timed_out = true;
+                    break;
+                }
+            }
+            drop(is_loading);
+            if timed_out {
+                warn!(
+                    "Live preview: timed out after {:?} waiting for model load; \
+                     falling back to batch transcription",
+                    MODEL_LOAD_WAIT_TIMEOUT
+                );
+                self.router.clear();
+                drain_until_finalize(rx);
+                return;
             }
         }
 
@@ -1052,6 +1129,19 @@ impl TranscriptionManager {
             Err(mpsc::RecvTimeoutError::Disconnected) => return Ok(None),
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 self.stream_active.store(false, Ordering::Release);
+                // The worker may be wedged in a native finalize and still holding
+                // the engine lease (the engine is taken out of the mutex while
+                // leased). Left set, the lease makes is_model_loaded() report
+                // "loaded" forever even though the engine mutex is empty, so
+                // initiate_model_load early-returns and never reloads — every
+                // later dictation then fails with "model not loaded". Force-clear
+                // the lease/worker tokens and the router so the next use reloads a
+                // fresh engine. If the stuck worker ever returns, its
+                // StreamWorkerGuard CAS is now a no-op and return_engine's id
+                // check drops the stale engine.
+                self.active_engine_lease.store(0, Ordering::Release);
+                self.active_stream_worker.store(0, Ordering::Release);
+                self.router.clear();
                 return Err(anyhow::anyhow!(
                     "Timed out waiting {:?} for live transcription to finalize",
                     STREAM_FINALIZE_REPLY_TIMEOUT
@@ -1117,10 +1207,28 @@ impl TranscriptionManager {
 
         // Check if model is loaded, if not try to load it
         {
-            // If the model is loading, wait for it to complete.
+            // If the model is loading, wait for it to complete — but with a hard
+            // cap so a wedged/panicked loader can't block dictation forever.
+            let deadline = Instant::now() + MODEL_LOAD_WAIT_TIMEOUT;
             let mut is_loading = self.is_loading.lock().unwrap();
             while *is_loading {
-                is_loading = self.loading_condvar.wait(is_loading).unwrap();
+                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                    return Err(anyhow::anyhow!(
+                        "Model load timed out after {:?}; model unavailable.",
+                        MODEL_LOAD_WAIT_TIMEOUT
+                    ));
+                };
+                let (guard, wait_res) = self
+                    .loading_condvar
+                    .wait_timeout(is_loading, remaining)
+                    .unwrap();
+                is_loading = guard;
+                if wait_res.timed_out() && *is_loading {
+                    return Err(anyhow::anyhow!(
+                        "Model load timed out after {:?}; model unavailable.",
+                        MODEL_LOAD_WAIT_TIMEOUT
+                    ));
+                }
             }
 
             let engine_guard = self.lock_engine();

--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -944,7 +944,7 @@ impl TranscriptionManager {
         };
 
         if !supports_streaming {
-            self.return_engine(engine, &model_id);
+            self.return_leased_engine(engine, &model_id, worker_id);
             self.router.clear();
             drain_until_finalize(rx);
             return;
@@ -1080,17 +1080,35 @@ impl TranscriptionManager {
             // failed); drain so the finalize handshake still completes and the
             // caller falls back to batch transcription. Return the engine first
             // so the fallback can immediately use it.
-            self.return_engine(engine, &model_id);
+            self.return_leased_engine(engine, &model_id, worker_id);
             drain_until_finalize(rx);
             return;
         }
 
-        self.return_engine(engine, &model_id);
+        self.return_leased_engine(engine, &model_id, worker_id);
         if let (Some(reply), Some(result)) = (finalize_reply, finalize_result) {
             let _ = reply.send(result);
         }
         // `_worker` drops here, clearing this worker's active/lease flags after
         // the engine has been returned to the pool.
+    }
+
+    /// Return a stream worker's leased engine, but only if the worker still
+    /// holds the lease. After a finalize timeout force-clears the lease (see
+    /// `finalize_stream`), a late-recovering worker must NOT reinject its stale
+    /// engine — `return_engine`'s model-id check alone can't catch that (the
+    /// selected model is often unchanged), so the reinjection would overwrite a
+    /// freshly loaded engine or race a newer worker's lease.
+    fn return_leased_engine(&self, engine: LoadedEngine, expected_model_id: &str, worker_id: u64) {
+        if self.active_engine_lease.load(Ordering::Acquire) != worker_id {
+            debug!(
+                "Stream worker {} no longer holds the engine lease (finalize timeout \
+                 force-clear or reassignment); dropping stale engine (was '{}')",
+                worker_id, expected_model_id
+            );
+            return; // `engine` drops here, freeing its resources.
+        }
+        self.return_engine(engine, expected_model_id);
     }
 
     /// Return the leased engine to the mutex, unless the model was switched or
@@ -1137,8 +1155,8 @@ impl TranscriptionManager {
                 // later dictation then fails with "model not loaded". Force-clear
                 // the lease/worker tokens and the router so the next use reloads a
                 // fresh engine. If the stuck worker ever returns, its
-                // StreamWorkerGuard CAS is now a no-op and return_engine's id
-                // check drops the stale engine.
+                // StreamWorkerGuard CAS is now a no-op and
+                // return_leased_engine's lease check drops the stale engine.
                 self.active_engine_lease.store(0, Ordering::Release);
                 self.active_stream_worker.store(0, Ordering::Release);
                 self.router.clear();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,4 +1,4 @@
-use log::{debug, warn};
+use log::{debug, error, warn};
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use specta::Type;
@@ -512,6 +512,11 @@ pub enum OverlayStyle {
     Live,
 }
 
+// serde's `snake_case` renames `Min2` -> "min2" (no underscore before a digit),
+// which is exactly what the frontend `<select>` sends, so this fork is NOT
+// affected by upstream Handy#1068 (backend expecting "min_2"). The generated
+// bindings.ts shows "min_2" because specta uses a different snake_case, but the
+// wire/store value is "min2" — see the round-trip test below.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelUnloadTimeout {
@@ -1590,11 +1595,36 @@ impl AppSettings {
     }
 }
 
+/// Open the settings store, retrying once before giving up. The store is a file
+/// on disk and its open can fail transiently under I/O pressure or a momentary
+/// lock — and this runs on many threads (the idle watcher included), so a panic
+/// here would take down an unrelated worker. Callers must degrade gracefully
+/// (default settings for reads, skip the write) when this returns `None`.
+fn open_settings_store<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+) -> Option<std::sync::Arc<tauri_plugin_store::Store<R>>> {
+    let path = crate::portable::store_path(SETTINGS_STORE_PATH);
+    match app.store(path.clone()) {
+        Ok(store) => Some(store),
+        Err(e) => {
+            warn!("Failed to open settings store ({e}); retrying once");
+            match app.store(path) {
+                Ok(store) => Some(store),
+                Err(e) => {
+                    error!("Failed to open settings store after retry: {e}");
+                    None
+                }
+            }
+        }
+    }
+}
+
 pub fn load_or_create_app_settings(app: &AppHandle) -> AppSettings {
     // Initialize store
-    let store = app
-        .store(crate::portable::store_path(SETTINGS_STORE_PATH))
-        .expect("Failed to initialize store");
+    let Some(store) = open_settings_store(app) else {
+        error!("Settings store unavailable; using default settings for this session");
+        return get_default_settings();
+    };
 
     let mut settings = if let Some(settings_value) = store.get("settings") {
         // Parse the entire settings object
@@ -1638,9 +1668,9 @@ pub fn load_or_create_app_settings(app: &AppHandle) -> AppSettings {
 }
 
 pub fn get_settings(app: &AppHandle) -> AppSettings {
-    let store = app
-        .store(crate::portable::store_path(SETTINGS_STORE_PATH))
-        .expect("Failed to initialize store");
+    let Some(store) = open_settings_store(app) else {
+        return get_default_settings();
+    };
 
     // Settings reads also persist one-time migrations. Migration helpers are
     // idempotent, so this converges after the first read of an older store.
@@ -1766,9 +1796,10 @@ fn apply_settings_migrations(
 }
 
 pub fn write_settings(app: &AppHandle, settings: AppSettings) {
-    let store = app
-        .store(crate::portable::store_path(SETTINGS_STORE_PATH))
-        .expect("Failed to initialize store");
+    let Some(store) = open_settings_store(app) else {
+        error!("Settings store unavailable; skipping settings write");
+        return;
+    };
 
     store.set("settings", serde_json::to_value(&settings).unwrap());
 }
@@ -1915,6 +1946,33 @@ mod tests {
 
         assert!(apply_settings_migrations(&mut settings, &raw));
         assert_eq!(settings.overlay_style, OverlayStyle::None);
+    }
+
+    #[test]
+    fn model_unload_timeout_roundtrips_frontend_spelling() {
+        // Regression guard for upstream Handy#1068 (backend expected "min_2"
+        // while the frontend sent "min2"). This fork's serde snake_case renames
+        // to "min2" — exactly what the ModelUnloadTimeout `<select>` sends — so a
+        // timeout selection deserializes and round-trips without silently acting
+        // as `never`. (The "min_2" in bindings.ts is a specta type-gen quirk, not
+        // the wire value.)
+        for (wire, expected) in [
+            ("min2", ModelUnloadTimeout::Min2),
+            ("min5", ModelUnloadTimeout::Min5),
+            ("min10", ModelUnloadTimeout::Min10),
+            ("min15", ModelUnloadTimeout::Min15),
+            ("hour1", ModelUnloadTimeout::Hour1),
+            ("sec15", ModelUnloadTimeout::Sec15),
+        ] {
+            let parsed: ModelUnloadTimeout = serde_json::from_value(serde_json::json!(wire))
+                .unwrap_or_else(|e| panic!("frontend spelling {wire} should parse: {e}"));
+            assert_eq!(parsed, expected);
+            // Serializes back to the same string the frontend sends.
+            assert_eq!(
+                serde_json::to_value(parsed).unwrap(),
+                serde_json::json!(wire)
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -9,6 +9,14 @@ use tauri::{AppHandle, Manager};
 
 const DEBOUNCE: Duration = Duration::from_millis(30);
 
+/// Safety cap on the `Processing` stage. The async transcribe/paste pipeline
+/// always sends `ProcessingFinished` when it completes (via a `FinishGuard` that
+/// fires even on panic), so `Processing` should be transient. If that signal is
+/// ever lost, `Processing` would stick and silently swallow every later hotkey
+/// press. After this generous cap, a fresh press force-resets to `Idle` and is
+/// honored, so the pipeline can never wedge permanently.
+const PROCESSING_WATCHDOG: Duration = Duration::from_secs(180);
+
 /// Commands processed sequentially by the coordinator thread.
 enum Command {
     Input {
@@ -75,6 +83,8 @@ impl TranscriptionCoordinator {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let mut stage = Stage::Idle;
                 let mut last_press: Option<Instant> = None;
+                // When the pipeline entered Processing, for the watchdog below.
+                let mut processing_since: Option<Instant> = None;
 
                 while let Ok(cmd) = rx.recv() {
                     match cmd {
@@ -102,6 +112,7 @@ impl TranscriptionCoordinator {
                                     && matches!(&stage, Stage::Recording(id) if id == &binding_id)
                                 {
                                     stop(&app, &mut stage, &binding_id, &hotkey_string);
+                                    processing_since = Some(Instant::now());
                                 }
                             } else if is_pressed {
                                 match &stage {
@@ -110,6 +121,23 @@ impl TranscriptionCoordinator {
                                     }
                                     Stage::Recording(id) if id == &binding_id => {
                                         stop(&app, &mut stage, &binding_id, &hotkey_string);
+                                        processing_since = Some(Instant::now());
+                                    }
+                                    // Watchdog: if Processing has stuck past the cap
+                                    // (a lost ProcessingFinished), force back to Idle
+                                    // and honor this press instead of ignoring it
+                                    // forever.
+                                    _ if matches!(stage, Stage::Processing)
+                                        && processing_since
+                                            .is_some_and(|t| t.elapsed() > PROCESSING_WATCHDOG) =>
+                                    {
+                                        warn!(
+                                            "Processing stuck >{PROCESSING_WATCHDOG:?}; \
+                                             force-resetting to Idle and honoring press for '{binding_id}'"
+                                        );
+                                        processing_since = None;
+                                        stage = Stage::Idle;
+                                        start(&app, &mut stage, &binding_id, &hotkey_string);
                                     }
                                     _ => {
                                         debug!("Ignoring press for '{binding_id}': pipeline busy")
@@ -129,6 +157,7 @@ impl TranscriptionCoordinator {
                         }
                         Command::ProcessingFinished => {
                             stage = Stage::Idle;
+                            processing_since = None;
                         }
                     }
                 }

--- a/src-tauri/src/transcription_coordinator.rs
+++ b/src-tauri/src/transcription_coordinator.rs
@@ -156,8 +156,7 @@ impl TranscriptionCoordinator {
                             }
                         }
                         Command::ProcessingFinished => {
-                            stage = Stage::Idle;
-                            processing_since = None;
+                            on_processing_finished(&mut stage, &mut processing_since);
                         }
                     }
                 }
@@ -238,9 +237,53 @@ fn stop(app: &AppHandle, stage: &mut Stage, binding_id: &str, hotkey_string: &st
     *stage = Stage::Processing;
 }
 
+/// Handle `ProcessingFinished`: only meaningful while `Processing`. A stale
+/// signal from an old run — arriving after the watchdog already force-reset to
+/// `Idle` and a new recording began — must not clobber the newer stage, or the
+/// in-flight recording would be orphaned and the next press would double-start.
+fn on_processing_finished(stage: &mut Stage, processing_since: &mut Option<Instant>) {
+    if matches!(stage, Stage::Processing) {
+        *stage = Stage::Idle;
+        *processing_since = None;
+    } else {
+        debug!("Ignoring stale ProcessingFinished: pipeline is no longer in Processing");
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{is_agent_binding, is_mode_binding, is_transcribe_binding};
+    use super::{
+        is_agent_binding, is_mode_binding, is_transcribe_binding, on_processing_finished, Stage,
+    };
+    use std::time::Instant;
+
+    #[test]
+    fn processing_finished_resets_processing_to_idle() {
+        let mut stage = Stage::Processing;
+        let mut since = Some(Instant::now());
+        on_processing_finished(&mut stage, &mut since);
+        assert!(matches!(stage, Stage::Idle));
+        assert!(since.is_none());
+    }
+
+    #[test]
+    fn stale_processing_finished_does_not_clobber_new_recording() {
+        // Watchdog fired during a wedged run and a new recording began; the old
+        // run's late ProcessingFinished must leave the new recording untouched.
+        let mut stage = Stage::Recording("transcribe".to_string());
+        let mut since = None;
+        on_processing_finished(&mut stage, &mut since);
+        assert!(matches!(&stage, Stage::Recording(id) if id == "transcribe"));
+    }
+
+    #[test]
+    fn stale_processing_finished_is_noop_when_idle() {
+        let mut stage = Stage::Idle;
+        let mut since = None;
+        on_processing_finished(&mut stage, &mut since);
+        assert!(matches!(stage, Stage::Idle));
+        assert!(since.is_none());
+    }
 
     #[test]
     fn recognizes_agent_bindings() {


### PR DESCRIPTION
## Before Submitting This PR

**Please confirm you have done the following:**

- [x] I have searched existing issues and pull requests (including closed ones) to ensure this isn't a duplicate
- [x] I have read CONTRIBUTING.md

## Human Written Description

<!-- TODO(human contributor): please replace this with 2-3 sentences in your own
voice — what you noticed on the Mac mini and why hardening the model-load/dictation
failure paths matters to you. The section below is AI-assisted and should not stand
in for your own words. -->

## Summary

Failure-path-only hardening for the model idle-unload → reload path and the
dictation pipeline. **Every change is on an error/timeout/panic path; the core
happy-path dictation loop (hotkey → capture → STT → cleanup → inject) is
byte-for-byte unchanged**, per the non-breaking principle in AGENTS.md.

### Symptoms
- After the model idle-unloads, it won't auto-reload — the hotkey silently does nothing.
- Clicking a model in the UI reports "failed to load" / "load already in progress" until an app restart.
- The app hangs entirely (observed on the Intel Mac mini) with no way out but a restart.

### Root-cause chain
`initiate_model_load()` manually set `is_loading = true`, spawned a thread that
called `load_model`, and reset the flag afterwards. Native whisper/GGML/Metal/ONNX
loaders can **panic** (not just `Err`); a panic killed the thread before the reset,
leaving `is_loading` stuck `true` forever. From there:
- the lazy hotkey reload early-returns forever (`is_loading` guard),
- UI model loads fail with "load already in progress",
- `transcribe()` and `run_stream_worker()` block on the `loading_condvar` with an
  **unbounded** wait → permanent hang.

Two secondary wedges compounded it: the hotkey path ran `tm.transcribe()`
synchronously on a Tokio worker; and a lost `ProcessingFinished` left the
coordinator stuck in `Stage::Processing`, silently ignoring all later presses.

### What each commit does
1. **panic-safe model reload** — `initiate_model_load()` now uses the existing
   `try_start_loading()`/`LoadingGuard` RAII (guard moved into the spawned thread,
   so `is_loading` is cleared and condvar waiters woken on *every* exit incl.
   panic), wraps `load_model` in `catch_unwind` to log the payload, and emits the
   existing `loading_failed` event so the UI toasts a real error. Also: 120s
   bounded `wait_timeout` in `transcribe()`/`run_stream_worker()` instead of an
   unbounded wait; and on stream-finalize timeout the engine lease + worker tokens
   are force-cleared so a wedged worker can't keep `is_model_loaded()` true and
   block reloads.
2. **spawn_blocking** — the hotkey batch-transcribe call is wrapped in
   `spawn_blocking` (matching `commands/history.rs` / `commands/backends.rs`) so it
   never parks a Tokio worker.
3. **coordinator watchdog** — records when `Processing` began; a press that would
   be ignored while Processing has been active >180s force-resets to `Idle` and is
   honored. Additive; state machine otherwise untouched.
4. **recorder stop timeout** — `AudioRecorder::stop()` uses `recv_timeout(10s)`
   instead of an unbounded `recv()`.
5. **settings-store panics** — `load_or_create_app_settings`/`get_settings`/
   `write_settings` no longer `.expect()` on store open; a shared helper retries
   once and returns `None`, so reads fall back to defaults and writes are skipped
   with an error log rather than panicking a thread (e.g. the idle watcher). Also
   documents + regression-tests `ModelUnloadTimeout` serde encoding (see below).

### Model-unload-timeout serialization check (upstream Handy#1068)
Checked and **no mismatch in this fork**. serde's `snake_case` renames `Min2` →
`"min2"` (no underscore before a digit), which is exactly what the frontend
`ModelUnloadTimeout` `<select>` sends, so timeouts persist correctly. The `"min_2"`
seen in `bindings.ts` is a *specta* type-gen quirk (different snake_case), not the
wire/store value — the component already works around it with an `as` cast. Added a
round-trip test to lock this in. No serde change was needed (no `alias` added).

## Related Issues

Fixes #

## Testing

- `cargo build` (src-tauri, Intel `x86_64-apple-darwin`, dynamic ORT) — succeeds.
- `cargo test --lib` — **313 passed, 0 failed** (incl. a new
  `model_unload_timeout_roundtrips_frontend_spelling` regression test).
- `cargo fmt --check` — clean.
- No frontend files changed, so `tsc` typecheck is unaffected.

Suggested manual test plan:
1. Set unload timeout to 2 min; let the model idle-unload; press the hotkey →
   model reloads and dictation works (previously wedged).
2. With `HANDY_FORCE_TRANSCRIPTION_FAILURE`/a forced loader panic, confirm the UI
   toasts a load error and the *next* press reloads cleanly instead of hanging.
3. Rapid hotkey presses during transcription → no hang; pipeline recovers.

## Screenshots/Videos (if applicable)

N/A (backend-only).

## AI Assistance

- [ ] No AI was used in this PR
- [x] AI was used (please describe below)

**If AI was used:**

- Tools used: Claude Code (Opus)
- How extensively: Diagnosis and implementation of all five failure-path commits,
  tests, and this description. Human contributor to review and add the Human
  Written Description above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
