### PR TITLE
feat(agents): remote agents over A2A — rebased on current main (comparison of #43)

### DIFF
--- a/src-tauri/src/a2a.rs
+++ b/src-tauri/src/a2a.rs
@@ -580,6 +580,63 @@ impl SseParser {
 }
 
 // ---------------------------------------------------------------------------
+// Incremental UTF-8 decoder (network chunk boundaries do NOT respect UTF-8
+// char boundaries; decoding each chunk independently would turn a multi-byte
+// character split across two chunks into replacement chars)
+// ---------------------------------------------------------------------------
+
+/// Decodes a byte stream to UTF-8 incrementally, holding back an INCOMPLETE
+/// trailing multi-byte sequence until its continuation bytes arrive in a later
+/// chunk. A genuinely invalid sequence is emitted as one replacement char (and
+/// skipped) so a hostile/broken stream can't stall the decoder.
+#[derive(Default)]
+pub struct Utf8Buffer {
+    tail: Vec<u8>,
+}
+
+impl Utf8Buffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push raw bytes; return the longest now-decodable UTF-8 text, retaining
+    /// any incomplete trailing sequence for the next call.
+    pub fn push(&mut self, bytes: &[u8]) -> String {
+        self.tail.extend_from_slice(bytes);
+        let mut out = String::new();
+        loop {
+            match std::str::from_utf8(&self.tail) {
+                Ok(s) => {
+                    out.push_str(s);
+                    self.tail.clear();
+                    break;
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    if valid > 0 {
+                        // SAFETY-of-logic: bytes[..valid] is valid UTF-8 by definition.
+                        out.push_str(std::str::from_utf8(&self.tail[..valid]).unwrap_or(""));
+                    }
+                    match e.error_len() {
+                        // Incomplete (could still become valid) — keep the tail.
+                        None => {
+                            self.tail.drain(..valid);
+                            break;
+                        }
+                        // Genuinely invalid — emit one replacement, skip it, continue.
+                        Some(bad) => {
+                            out.push('\u{FFFD}');
+                            self.tail.drain(..valid + bad);
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Transport (mirror of ServiceTransport: HTTP behind a trait so the driver is
 // unit-testable against a mock with no network)
 // ---------------------------------------------------------------------------
@@ -738,11 +795,13 @@ impl A2aTransport for HttpA2aTransport {
 
         struct StreamState<S> {
             inner: S,
+            decoder: Utf8Buffer,
             parser: SseParser,
             queue: std::collections::VecDeque<String>,
         }
         let state = StreamState {
             inner: resp.bytes_stream(),
+            decoder: Utf8Buffer::new(),
             parser: SseParser::new(),
             queue: std::collections::VecDeque::new(),
         };
@@ -758,7 +817,9 @@ impl A2aTransport for HttpA2aTransport {
                 }
                 match st.inner.next().await {
                     Some(Ok(bytes)) => {
-                        let text = String::from_utf8_lossy(&bytes);
+                        // Decode incrementally: a multi-byte char split across a
+                        // network chunk boundary must not be mangled into U+FFFD.
+                        let text = st.decoder.push(&bytes);
                         for data in st.parser.feed(&text) {
                             st.queue.push_back(data);
                         }
@@ -1458,6 +1519,53 @@ mod tests {
         let out = p.feed("data: not json\n\n");
         assert_eq!(out, vec!["not json".to_string()]);
         assert!(serde_json::from_str::<Value>(&out[0]).is_err());
+    }
+
+    // ---- incremental UTF-8 decoder -----------------------------------------
+
+    #[test]
+    fn utf8_buffer_passes_ascii_through() {
+        let mut b = Utf8Buffer::new();
+        assert_eq!(b.push(b"hello"), "hello");
+        assert_eq!(b.push(b" world"), " world");
+    }
+
+    #[test]
+    fn utf8_buffer_reassembles_two_byte_char_split_across_chunks() {
+        // "é" = 0xC3 0xA9. Split between the two bytes at a chunk boundary.
+        let mut b = Utf8Buffer::new();
+        assert_eq!(b.push(&[0xC3]), ""); // incomplete — held back, NOT mangled
+        assert_eq!(b.push(&[0xA9]), "é");
+    }
+
+    #[test]
+    fn utf8_buffer_reassembles_four_byte_emoji_split_across_chunks() {
+        // "😀" = F0 9F 98 80. Feed it one byte at a time.
+        let bytes = "😀".as_bytes().to_vec();
+        let mut b = Utf8Buffer::new();
+        let mut out = String::new();
+        for byte in bytes {
+            out.push_str(&b.push(&[byte]));
+        }
+        assert_eq!(out, "😀");
+    }
+
+    #[test]
+    fn utf8_buffer_mixed_ascii_and_split_multibyte() {
+        // "aé" split so the ASCII 'a' plus the first byte of 'é' arrive together.
+        let mut b = Utf8Buffer::new();
+        assert_eq!(b.push(&[b'a', 0xC3]), "a");
+        assert_eq!(b.push(&[0xA9, b'b']), "éb");
+    }
+
+    #[test]
+    fn utf8_buffer_emits_replacement_for_genuinely_invalid_bytes() {
+        // A lone continuation byte 0x80 is invalid, not incomplete — must not
+        // stall the decoder; it yields one replacement and continues.
+        let mut b = Utf8Buffer::new();
+        let out = b.push(&[0x80, b'x']);
+        assert!(out.contains('x'), "got: {out:?}");
+        assert!(out.contains('\u{FFFD}'), "got: {out:?}");
     }
 
     #[test]

--- a/src-tauri/src/a2a.rs
+++ b/src-tauri/src/a2a.rs
@@ -1,0 +1,1854 @@
+//! Flow OS increment 3 — a thin, hand-rolled **A2A (Agent-to-Agent)** client for
+//! the `RemoteDriver`. A remote agent is a spec-compliant A2A server the user
+//! points OpenFlow at; it joins the same agent registry, hotkeys, voice routing
+//! and run panel as CLI/prompt agents (see `DESIGN-remote-agents.md`).
+//!
+//! Scope is deliberately narrow: the A2A **JSON-RPC binding** only (no gRPC /
+//! HTTP+JSON), built on `reqwest` + `serde_json` with NO `a2a-*` crates (pre-1.0
+//! churn + gRPC weight). We accept agent cards advertising `protocolVersion`
+//! 0.3.x AND 1.0.x — the two shapes are wire-identical for the four methods we
+//! use (`message/send`, `tasks/get`, `tasks/cancel`, `message/stream`).
+//!
+//! Everything here is pure/testable except the production `HttpA2aTransport`:
+//! card parsing, endpoint selection, JSON-RPC envelope handling, the SSE frame
+//! parser and the driver protocol loop all run against a mock transport with no
+//! network (see the tests at the bottom + the driver tests in `agent_run.rs`).
+
+use std::collections::HashSet;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use futures_util::{Stream, StreamExt};
+use serde::Serialize;
+use serde_json::{json, Value};
+use specta::Type;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
+
+// ---------------------------------------------------------------------------
+// Method strings (A2A JSON-RPC binding)
+// ---------------------------------------------------------------------------
+
+pub const METHOD_MESSAGE_SEND: &str = "message/send";
+pub const METHOD_MESSAGE_STREAM: &str = "message/stream";
+pub const METHOD_TASKS_GET: &str = "tasks/get";
+pub const METHOD_TASKS_CANCEL: &str = "tasks/cancel";
+
+// ---------------------------------------------------------------------------
+// Request ids (no `uuid` dependency — a unique-per-request id is all JSON-RPC
+// and A2A `messageId` need). Non-cryptographic; combines a process seed, the
+// clock and a monotonic counter, formatted UUID-v4-shaped for server-friendliness.
+// ---------------------------------------------------------------------------
+
+static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A unique request/message id, formatted like a v4 UUID.
+pub fn new_request_id() -> String {
+    let counter = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    // Two 64-bit lanes mixed with splitmix64 so the hex is well-distributed.
+    let a = splitmix64(nanos ^ (counter.wrapping_mul(0x9E37_79B9_7F4A_7C15)));
+    let b = splitmix64(counter ^ (nanos.rotate_left(32)));
+    let time_low = (a >> 32) as u32;
+    let time_mid = (a >> 16) as u16;
+    let time_hi = ((a as u16) & 0x0FFF) | 0x4000; // version 4
+    let clock = ((b >> 48) as u16 & 0x3FFF) | 0x8000; // variant 10xx
+    let node = b & 0xFFFF_FFFF_FFFF;
+    format!("{time_low:08x}-{time_mid:04x}-{time_hi:04x}-{clock:04x}-{node:012x}")
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = x;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+// ---------------------------------------------------------------------------
+// Agent card — tolerant parse of BOTH the v0.3 and v1.0 shapes
+// ---------------------------------------------------------------------------
+
+/// A normalized transport interface extracted from a card.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interface {
+    pub url: String,
+    pub transport: String,
+}
+
+/// The bits of an agent card OpenFlow cares about, normalized across card
+/// versions. Unknown fields are ignored (tolerant parse).
+#[derive(Debug, Clone)]
+pub struct AgentCard {
+    pub name: String,
+    pub version: String,
+    pub streaming: bool,
+    /// Transport interfaces in preference order (top-level/preferred first).
+    pub interfaces: Vec<Interface>,
+    pub auth_schemes: Vec<String>,
+    pub skills: Vec<AgentCardSkill>,
+}
+
+/// UI-facing summary returned by `fetch_remote_agent_card` / persisted on the agent.
+#[derive(Debug, Clone, Serialize, Type)]
+pub struct AgentCardSummary {
+    pub name: String,
+    pub version: String,
+    pub streaming: bool,
+    /// The resolved JSON-RPC endpoint (empty only if selection somehow failed —
+    /// callers error out before building a summary in that case).
+    pub endpoint: String,
+    pub auth_schemes: Vec<String>,
+    pub skills: Vec<AgentCardSkill>,
+}
+
+#[derive(Debug, Clone, Serialize, Type, PartialEq, Eq)]
+pub struct AgentCardSkill {
+    pub id: String,
+    pub name: String,
+}
+
+/// Derive the well-known agent-card URL from a user-entered base URL. A URL that
+/// already points at a card (`…/agent-card.json` or an `…/.well-known/…` path)
+/// is accepted verbatim; otherwise we append the well-known path to the origin+path.
+pub fn well_known_card_url(entered: &str) -> String {
+    let trimmed = entered.trim();
+    if trimmed.ends_with("agent-card.json") || trimmed.contains("/.well-known/") {
+        return trimmed.to_string();
+    }
+    let base = trimmed.trim_end_matches('/');
+    format!("{base}/.well-known/agent-card.json")
+}
+
+/// Parse an agent card JSON value into the normalized [`AgentCard`]. Accepts the
+/// v0.3 shape (`url` + `preferredTransport` + `additionalInterfaces`) and the
+/// v1.0 shape (`supportedInterfaces`), merging both when present.
+pub fn parse_agent_card(v: &Value) -> Result<AgentCard, String> {
+    if !v.is_object() {
+        return Err("The agent card was not a JSON object.".to_string());
+    }
+    let name = v
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let version = v
+        .get("version")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let streaming = v
+        .get("capabilities")
+        .and_then(|c| c.get("streaming"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut interfaces: Vec<Interface> = Vec::new();
+
+    // v0.3 top-level url + preferredTransport. Per the A2A spec, when
+    // `preferredTransport` is omitted the transport at `url` is JSONRPC.
+    if let Some(url) = v.get("url").and_then(Value::as_str) {
+        if !url.is_empty() {
+            let transport = v
+                .get("preferredTransport")
+                .and_then(Value::as_str)
+                .unwrap_or("JSONRPC")
+                .to_string();
+            interfaces.push(Interface {
+                url: url.to_string(),
+                transport,
+            });
+        }
+    }
+    // v0.3 additionalInterfaces: [{url, transport}].
+    if let Some(arr) = v.get("additionalInterfaces").and_then(Value::as_array) {
+        for it in arr {
+            if let Some(url) = it.get("url").and_then(Value::as_str) {
+                let transport = it
+                    .get("transport")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                interfaces.push(Interface {
+                    url: url.to_string(),
+                    transport,
+                });
+            }
+        }
+    }
+    // v1.0 supportedInterfaces: [{url, protocolBinding|transport, protocolVersion}].
+    if let Some(arr) = v.get("supportedInterfaces").and_then(Value::as_array) {
+        for it in arr {
+            if let Some(url) = it.get("url").and_then(Value::as_str) {
+                let transport = it
+                    .get("protocolBinding")
+                    .or_else(|| it.get("transport"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                interfaces.push(Interface {
+                    url: url.to_string(),
+                    transport,
+                });
+            }
+        }
+    }
+
+    let auth_schemes = parse_auth_schemes(v);
+    let skills = parse_skills(v);
+
+    Ok(AgentCard {
+        name,
+        version,
+        streaming,
+        interfaces,
+        auth_schemes,
+        skills,
+    })
+}
+
+fn parse_auth_schemes(v: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(obj) = v.get("securitySchemes").and_then(Value::as_object) {
+        for scheme in obj.values() {
+            if let Some(t) = scheme.get("type").and_then(Value::as_str) {
+                if !out.iter().any(|s| s == t) {
+                    out.push(t.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn parse_skills(v: &Value) -> Vec<AgentCardSkill> {
+    v.get("skills")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| {
+                    let id = s.get("id").and_then(Value::as_str)?.to_string();
+                    let name = s
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or(&id)
+                        .to_string();
+                    Some(AgentCardSkill { id, name })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Normalize a transport/binding label to a comparable token (lowercase, only
+/// alphanumerics) so `JSONRPC`, `jsonrpc`, `JSON-RPC` all compare equal.
+fn transport_token(t: &str) -> String {
+    t.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+fn is_jsonrpc(t: &str) -> bool {
+    transport_token(t) == "jsonrpc"
+}
+
+impl AgentCard {
+    /// Select the JSON-RPC endpoint URL: the first interface (in preference
+    /// order) whose transport is JSON-RPC. Errors clearly when none exists.
+    pub fn select_jsonrpc_endpoint(&self) -> Result<String, String> {
+        self.interfaces
+            .iter()
+            .find(|i| is_jsonrpc(&i.transport) && !i.url.is_empty())
+            .map(|i| i.url.clone())
+            .ok_or_else(|| {
+                "This agent doesn't offer a JSON-RPC interface. OpenFlow only \
+                 speaks the A2A JSON-RPC binding."
+                    .to_string()
+            })
+    }
+
+    pub fn summary(&self, endpoint: String) -> AgentCardSummary {
+        AgentCardSummary {
+            name: self.name.clone(),
+            version: self.version.clone(),
+            streaming: self.streaming,
+            endpoint,
+            auth_schemes: self.auth_schemes.clone(),
+            skills: self.skills.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC envelope
+// ---------------------------------------------------------------------------
+
+/// A JSON-RPC 2.0 request body.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: &'static str,
+    pub id: String,
+    pub method: String,
+    pub params: Value,
+}
+
+impl JsonRpcRequest {
+    pub fn new(method: &str, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id: new_request_id(),
+            method: method.to_string(),
+            params,
+        }
+    }
+}
+
+/// Parse a JSON-RPC response envelope: **error before result** (a well-formed
+/// error response can technically also carry a null `result`). Returns the
+/// `result` value on success, or a formatted `code: message` error string.
+pub fn parse_jsonrpc_envelope(v: &Value) -> Result<Value, String> {
+    if let Some(err) = v.get("error") {
+        if !err.is_null() {
+            let code = err.get("code").and_then(Value::as_i64).unwrap_or(0);
+            let message = err
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown error");
+            return Err(format!("{code}: {message}"));
+        }
+    }
+    match v.get("result") {
+        Some(result) if !result.is_null() => Ok(result.clone()),
+        _ => Err("the response had neither a result nor an error".to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Message / Part / Task text extraction
+// ---------------------------------------------------------------------------
+
+/// Build the `message/send`|`message/stream` params for an instruction.
+pub fn build_send_params(instruction: &str) -> Value {
+    json!({
+        "message": {
+            "role": "user",
+            "parts": [{ "kind": "text", "text": instruction }],
+            "messageId": new_request_id(),
+        }
+    })
+}
+
+/// Turn one A2A `Part` into a displayable line. Text parts yield their text;
+/// non-text parts are summarized (`[file: name]` / `[data]`) rather than dumped.
+pub fn part_to_text(part: &Value) -> Option<String> {
+    let kind = part
+        .get("kind")
+        .or_else(|| part.get("type"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    match kind {
+        "file" => {
+            let name = part
+                .get("file")
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("file");
+            Some(format!("[file: {name}]"))
+        }
+        "data" => Some("[data]".to_string()),
+        // "text" or an unlabeled part that nonetheless carries text.
+        _ => part
+            .get("text")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string()),
+    }
+}
+
+/// Collect the displayable text chunks from a `parts` array.
+fn parts_text(parts: Option<&Value>) -> Vec<String> {
+    parts
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(part_to_text).collect())
+        .unwrap_or_default()
+}
+
+/// Extract text chunks from a `message` result (direct reply).
+pub fn message_text(msg: &Value) -> Vec<String> {
+    parts_text(msg.get("parts"))
+}
+
+/// Extract the NEW-this-snapshot text chunks from a `task`: its status message
+/// parts plus every artifact's parts. Callers dedupe across polls.
+pub fn task_text_chunks(task: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(status) = task.get("status") {
+        out.extend(parts_text(
+            status.get("message").and_then(|m| m.get("parts")),
+        ));
+    }
+    if let Some(arts) = task.get("artifacts").and_then(Value::as_array) {
+        for art in arts {
+            out.extend(parts_text(art.get("parts")));
+        }
+    }
+    out
+}
+
+/// The `state` string of a task/status object, if present.
+pub fn task_state(task: &Value) -> Option<String> {
+    task.get("status")
+        .and_then(|s| s.get("state"))
+        .or_else(|| task.get("state"))
+        .and_then(Value::as_str)
+        .map(|s| s.to_string())
+}
+
+/// The human message attached to a task/status, if any (used in Failed text).
+pub fn task_status_message(task: &Value) -> Option<String> {
+    let parts = task
+        .get("status")
+        .and_then(|s| s.get("message"))
+        .and_then(|m| m.get("parts"));
+    let text = parts_text(parts).join(" ");
+    if text.trim().is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// send-result dispatch + task-state classification
+// ---------------------------------------------------------------------------
+
+/// What a `message/send` result represents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendDispatch {
+    /// A direct reply — the concatenated text is final.
+    DirectMessage(Vec<String>),
+    /// A long-running task to track by id (with any text already present).
+    Task {
+        id: String,
+        initial_text: Vec<String>,
+    },
+    /// A task with no id — unusable (server bug); surfaced as a failure.
+    UnusableTask,
+}
+
+/// Dispatch a `message/send` result on its `kind` (`"message"` vs `"task"`),
+/// with a structural fallback for cards that omit `kind`.
+pub fn dispatch_send_result(result: &Value) -> SendDispatch {
+    let kind = result.get("kind").and_then(Value::as_str);
+    let looks_like_task = result.get("status").is_some() || result.get("artifacts").is_some();
+    let is_task = matches!(kind, Some("task")) || (kind.is_none() && looks_like_task);
+    if is_task {
+        match result.get("id").and_then(Value::as_str) {
+            Some(id) if !id.is_empty() => SendDispatch::Task {
+                id: id.to_string(),
+                initial_text: task_text_chunks(result),
+            },
+            _ => SendDispatch::UnusableTask,
+        }
+    } else {
+        SendDispatch::DirectMessage(message_text(result))
+    }
+}
+
+/// Terminal/non-terminal classification of an A2A task state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateClass {
+    /// `submitted` / `working` — keep going.
+    NonTerminal,
+    /// `completed`.
+    Finished,
+    /// `failed` / `rejected` — carries the server message when present.
+    Failed(Option<String>),
+    /// `canceled`.
+    Stopped,
+    /// `input-required` / `auth-required` — multi-turn, unsupported in v1.
+    NeedsInput,
+    /// An unrecognized state string — treated as non-terminal (keep polling).
+    Unknown,
+}
+
+/// Map an A2A task `state` string to its [`StateClass`].
+pub fn classify_state(state: &str, server_message: Option<String>) -> StateClass {
+    match state {
+        "submitted" | "working" => StateClass::NonTerminal,
+        "completed" => StateClass::Finished,
+        "failed" | "rejected" => StateClass::Failed(server_message),
+        "canceled" | "cancelled" => StateClass::Stopped,
+        "input-required" | "auth-required" => StateClass::NeedsInput,
+        _ => StateClass::Unknown,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Poll-append dedupe
+// ---------------------------------------------------------------------------
+
+/// Tracks text chunks already emitted so re-polling a task (whose artifacts/
+/// status message accumulate) doesn't re-print what the user already saw.
+#[derive(Default)]
+pub struct TextDedup {
+    seen: HashSet<String>,
+}
+
+impl TextDedup {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return `Some(text)` the first time a chunk is seen, `None` afterwards.
+    pub fn push(&mut self, text: &str) -> Option<String> {
+        if text.is_empty() {
+            return None;
+        }
+        if self.seen.insert(text.to_string()) {
+            Some(text.to_string())
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SSE frame parser (manual; feed decoded text, get complete event data payloads)
+// ---------------------------------------------------------------------------
+
+/// A minimal Server-Sent-Events parser sufficient for A2A `message/stream`:
+/// handles multi-line `data:` (joined with `\n`), comment lines (`:` prefix),
+/// CRLF line endings, and events split across chunk boundaries. Non-`data`
+/// fields (`event`, `id`, `retry`) are ignored — each A2A frame is a JSON-RPC
+/// envelope carried entirely in `data`.
+#[derive(Default)]
+pub struct SseParser {
+    buf: String,
+    data_lines: Vec<String>,
+}
+
+impl SseParser {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed a decoded text chunk; return the `data` payload of every event that
+    /// completed (was terminated by a blank line) within it.
+    pub fn feed(&mut self, chunk: &str) -> Vec<String> {
+        self.buf.push_str(chunk);
+        let mut out = Vec::new();
+        while let Some(nl) = self.buf.find('\n') {
+            let mut line: String = self.buf.drain(..=nl).collect();
+            line.pop(); // drop the '\n'
+            if line.ends_with('\r') {
+                line.pop();
+            }
+            if line.is_empty() {
+                // Blank line — dispatch the buffered event (if any).
+                if !self.data_lines.is_empty() {
+                    out.push(self.data_lines.join("\n"));
+                    self.data_lines.clear();
+                }
+                continue;
+            }
+            if line.starts_with(':') {
+                continue; // comment
+            }
+            let (field, value) = match line.find(':') {
+                Some(i) => {
+                    let field = line[..i].to_string();
+                    let mut value = line[i + 1..].to_string();
+                    if let Some(stripped) = value.strip_prefix(' ') {
+                        value = stripped.to_string();
+                    }
+                    (field, value)
+                }
+                None => (line.clone(), String::new()),
+            };
+            if field == "data" {
+                self.data_lines.push(value);
+            }
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport (mirror of ServiceTransport: HTTP behind a trait so the driver is
+// unit-testable against a mock with no network)
+// ---------------------------------------------------------------------------
+
+/// A stream of parsed JSON-RPC `result` values (one per SSE frame). Each item is
+/// the frame's `result` object, or an error for a JSON-RPC-error frame / stream
+/// transport error.
+pub type A2aStream = Pin<Box<dyn Stream<Item = Result<Value, String>> + Send>>;
+
+/// The A2A operations the driver needs, behind a trait. Owned args keep the
+/// returned futures `'static` + `Send` (same pattern as `ServiceTransport`).
+pub trait A2aTransport: Send + Sync + 'static {
+    /// GET the agent card. `token` is used only for the 401-retry.
+    fn fetch_card(
+        &self,
+        url: String,
+        token: Option<String>,
+    ) -> impl std::future::Future<Output = Result<Value, String>> + Send;
+
+    /// POST a JSON-RPC call; returns the `result` (envelope error mapped to `Err`).
+    fn call(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> impl std::future::Future<Output = Result<Value, String>> + Send;
+
+    /// POST `message/stream`; returns a stream of per-frame `result` values.
+    fn stream(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> impl std::future::Future<Output = Result<A2aStream, String>> + Send;
+}
+
+/// Production transport backed by `reqwest`. Two clients: a 30s-timeout client
+/// for card fetch + unary calls, and a no-overall-timeout client for the SSE
+/// stream (an active stream's data keeps it alive; a total timeout would cut it).
+pub struct HttpA2aTransport {
+    unary: reqwest::Client,
+    streaming: reqwest::Client,
+}
+
+impl Default for HttpA2aTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpA2aTransport {
+    pub fn new() -> Self {
+        let unary = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        let streaming = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        Self { unary, streaming }
+    }
+}
+
+impl A2aTransport for HttpA2aTransport {
+    async fn fetch_card(&self, url: String, token: Option<String>) -> Result<Value, String> {
+        // Card fetch is an unauthenticated GET; if it 401s AND we have a token,
+        // retry once with the bearer token (covers protected cards).
+        let resp = self
+            .unary
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("Could not reach the agent: {e}"))?;
+        let status = resp.status();
+        if status.as_u16() == 401 {
+            if let Some(t) = token {
+                let resp2 = self
+                    .unary
+                    .get(&url)
+                    .bearer_auth(t)
+                    .send()
+                    .await
+                    .map_err(|e| format!("Could not reach the agent: {e}"))?;
+                if !resp2.status().is_success() {
+                    return Err(format!("HTTP {}", resp2.status().as_u16()));
+                }
+                return resp2
+                    .json()
+                    .await
+                    .map_err(|e| format!("The agent card was not valid JSON: {e}"));
+            }
+            return Err("HTTP 401".to_string());
+        }
+        if !status.is_success() {
+            return Err(format!("HTTP {}", status.as_u16()));
+        }
+        resp.json()
+            .await
+            .map_err(|e| format!("The agent card was not valid JSON: {e}"))
+    }
+
+    async fn call(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> Result<Value, String> {
+        let req = JsonRpcRequest::new(&method, params);
+        let mut builder = self.unary.post(&endpoint).json(&req);
+        if let Some(t) = token {
+            builder = builder.bearer_auth(t);
+        }
+        let resp = builder
+            .send()
+            .await
+            .map_err(|e| format!("request failed: {e}"))?;
+        // A2A returns JSON-RPC envelopes even on some non-2xx; parse the body and
+        // let envelope error-handling win, falling back to the HTTP status.
+        let status = resp.status();
+        let body: Value = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(format!("HTTP {}: {e}", status.as_u16()));
+            }
+        };
+        parse_jsonrpc_envelope(&body)
+    }
+
+    async fn stream(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> Result<A2aStream, String> {
+        let req = JsonRpcRequest::new(&method, params);
+        let mut builder = self
+            .streaming
+            .post(&endpoint)
+            .header("Accept", "text/event-stream")
+            .json(&req);
+        if let Some(t) = token {
+            builder = builder.bearer_auth(t);
+        }
+        let resp = builder
+            .send()
+            .await
+            .map_err(|e| format!("stream request failed: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("HTTP {}", resp.status().as_u16()));
+        }
+
+        struct StreamState<S> {
+            inner: S,
+            parser: SseParser,
+            queue: std::collections::VecDeque<String>,
+        }
+        let state = StreamState {
+            inner: resp.bytes_stream(),
+            parser: SseParser::new(),
+            queue: std::collections::VecDeque::new(),
+        };
+
+        let s = futures_util::stream::unfold(state, |mut st| async move {
+            loop {
+                // Drain already-parsed frames first, skipping non-JSON garbage.
+                while let Some(data) = st.queue.pop_front() {
+                    match serde_json::from_str::<Value>(&data) {
+                        Ok(env) => return Some((parse_jsonrpc_envelope(&env), st)),
+                        Err(_) => continue, // tolerate garbage frames
+                    }
+                }
+                match st.inner.next().await {
+                    Some(Ok(bytes)) => {
+                        let text = String::from_utf8_lossy(&bytes);
+                        for data in st.parser.feed(&text) {
+                            st.queue.push_back(data);
+                        }
+                        continue;
+                    }
+                    Some(Err(e)) => {
+                        return Some((Err(format!("stream error: {e}")), st));
+                    }
+                    None => return None,
+                }
+            }
+        });
+        Ok(Box::pin(s))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driver protocol loop (the RemoteDriver's core — transport-agnostic, testable)
+// ---------------------------------------------------------------------------
+
+/// Terminal outcome of a remote run, mapped to a `RunStatus` by the driver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteOutcome {
+    /// `completed` → `Finished { code: 0 }`.
+    Finished,
+    /// Any error / `failed` / `rejected` / unsupported-multiturn / timeout.
+    Failed(String),
+    /// `canceled` on the server, or a local stop request.
+    Stopped,
+}
+
+/// Production timings.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+pub const POLL_CAP: Duration = Duration::from_secs(15 * 60);
+
+/// Drive one remote run to a terminal outcome. `on_output` receives each new
+/// text chunk (streamed live by the driver into the run panel). `kill_rx`
+/// requests a stop. `poll_interval`/`poll_cap` are injectable for tests.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_remote_protocol<T, F>(
+    transport: &T,
+    endpoint: &str,
+    token: Option<String>,
+    instruction: &str,
+    streaming: bool,
+    kill_rx: &mut mpsc::UnboundedReceiver<()>,
+    on_output: &mut F,
+    poll_interval: Duration,
+    poll_cap: Duration,
+) -> RemoteOutcome
+where
+    T: A2aTransport,
+    F: FnMut(&str) + Send,
+{
+    let deadline = Instant::now() + poll_cap;
+    let mut dedup = TextDedup::new();
+
+    if streaming {
+        match stream_phase(
+            transport,
+            endpoint,
+            &token,
+            instruction,
+            kill_rx,
+            &mut dedup,
+            on_output,
+        )
+        .await
+        {
+            StreamPhase::Terminal(outcome) => return outcome,
+            StreamPhase::Stopped => return RemoteOutcome::Stopped,
+            StreamPhase::Fallback(task_id) => {
+                // Stream broke mid-way but we have a task id — degrade to polling.
+                return poll_phase(
+                    transport,
+                    endpoint,
+                    &token,
+                    &task_id,
+                    kill_rx,
+                    &mut dedup,
+                    on_output,
+                    poll_interval,
+                    deadline,
+                )
+                .await;
+            }
+        }
+    }
+
+    // Non-streaming: message/send, then dispatch.
+    let result = match transport
+        .call(
+            endpoint.to_string(),
+            token.clone(),
+            METHOD_MESSAGE_SEND.to_string(),
+            build_send_params(instruction),
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return RemoteOutcome::Failed(e),
+    };
+
+    match dispatch_send_result(&result) {
+        SendDispatch::DirectMessage(chunks) => {
+            for c in chunks {
+                if let Some(text) = dedup.push(&c) {
+                    on_output(&text);
+                }
+            }
+            RemoteOutcome::Finished
+        }
+        SendDispatch::UnusableTask => {
+            RemoteOutcome::Failed("the server returned a task with no id".to_string())
+        }
+        SendDispatch::Task { id, initial_text } => {
+            for c in initial_text {
+                if let Some(text) = dedup.push(&c) {
+                    on_output(&text);
+                }
+            }
+            // The initial response may already be terminal.
+            if let Some(state) = task_state(&result) {
+                if let Some(outcome) = terminal_outcome(&state, task_status_message(&result)) {
+                    return outcome;
+                }
+            }
+            poll_phase(
+                transport,
+                endpoint,
+                &token,
+                &id,
+                kill_rx,
+                &mut dedup,
+                on_output,
+                poll_interval,
+                deadline,
+            )
+            .await
+        }
+    }
+}
+
+/// Convert a state string into a terminal [`RemoteOutcome`], or `None` if the
+/// state is non-terminal (keep going). Folds the `NeedsInput` case into the
+/// actionable "multi-turn isn't supported yet" failure.
+fn terminal_outcome(state: &str, server_message: Option<String>) -> Option<RemoteOutcome> {
+    match classify_state(state, server_message) {
+        StateClass::NonTerminal | StateClass::Unknown => None,
+        StateClass::Finished => Some(RemoteOutcome::Finished),
+        StateClass::Failed(msg) => Some(RemoteOutcome::Failed(match msg {
+            Some(m) => format!("the agent reported: {m}"),
+            None => "the agent reported a failure".to_string(),
+        })),
+        StateClass::Stopped => Some(RemoteOutcome::Stopped),
+        StateClass::NeedsInput => Some(RemoteOutcome::Failed(
+            "the agent needs interactive input — multi-turn isn't supported yet".to_string(),
+        )),
+    }
+}
+
+/// Poll `tasks/get` every `poll_interval` until the task is terminal, the poll
+/// cap (`deadline`) is hit, or a stop is requested (→ `tasks/cancel`).
+#[allow(clippy::too_many_arguments)]
+async fn poll_phase<T, F>(
+    transport: &T,
+    endpoint: &str,
+    token: &Option<String>,
+    task_id: &str,
+    kill_rx: &mut mpsc::UnboundedReceiver<()>,
+    dedup: &mut TextDedup,
+    on_output: &mut F,
+    poll_interval: Duration,
+    deadline: Instant,
+) -> RemoteOutcome
+where
+    T: A2aTransport,
+    F: FnMut(&str) + Send,
+{
+    loop {
+        // Wait one interval OR a stop request. A stop request wins immediately.
+        tokio::select! {
+            biased;
+            _ = kill_rx.recv() => {
+                let _ = transport
+                    .call(
+                        endpoint.to_string(),
+                        token.clone(),
+                        METHOD_TASKS_CANCEL.to_string(),
+                        json!({ "id": task_id }),
+                    )
+                    .await; // idempotent; TaskNotCancelable tolerated
+                return RemoteOutcome::Stopped;
+            }
+            _ = tokio::time::sleep(poll_interval) => {}
+        }
+
+        if Instant::now() >= deadline {
+            return RemoteOutcome::Failed(
+                "timed out; the task may still be running on the server".to_string(),
+            );
+        }
+
+        let task = match transport
+            .call(
+                endpoint.to_string(),
+                token.clone(),
+                METHOD_TASKS_GET.to_string(),
+                json!({ "id": task_id, "historyLength": 0 }),
+            )
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => return RemoteOutcome::Failed(e),
+        };
+
+        for c in task_text_chunks(&task) {
+            if let Some(text) = dedup.push(&c) {
+                on_output(&text);
+            }
+        }
+
+        if let Some(state) = task_state(&task) {
+            if let Some(outcome) = terminal_outcome(&state, task_status_message(&task)) {
+                return outcome;
+            }
+        }
+    }
+}
+
+/// Result of the streaming phase.
+enum StreamPhase {
+    Terminal(RemoteOutcome),
+    Stopped,
+    /// Stream errored mid-way but a task id is known — the caller polls instead.
+    Fallback(String),
+}
+
+/// Consume `message/stream` frames, appending artifact/status text live, until a
+/// `final:true` / terminal state closes it, a stop is requested, or the stream
+/// errors (→ fallback poll if a task id was seen, else a failure).
+async fn stream_phase<T, F>(
+    transport: &T,
+    endpoint: &str,
+    token: &Option<String>,
+    instruction: &str,
+    kill_rx: &mut mpsc::UnboundedReceiver<()>,
+    dedup: &mut TextDedup,
+    on_output: &mut F,
+) -> StreamPhase
+where
+    T: A2aTransport,
+    F: FnMut(&str) + Send,
+{
+    let mut stream = match transport
+        .stream(
+            endpoint.to_string(),
+            token.clone(),
+            METHOD_MESSAGE_STREAM.to_string(),
+            build_send_params(instruction),
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => return StreamPhase::Terminal(RemoteOutcome::Failed(e)),
+    };
+
+    let mut task_id: Option<String> = None;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = kill_rx.recv() => {
+                if let Some(id) = &task_id {
+                    let _ = transport
+                        .call(
+                            endpoint.to_string(),
+                            token.clone(),
+                            METHOD_TASKS_CANCEL.to_string(),
+                            json!({ "id": id }),
+                        )
+                        .await;
+                }
+                return StreamPhase::Stopped;
+            }
+            frame = stream.next() => {
+                match frame {
+                    Some(Ok(result)) => {
+                        // Track a task id for cancel / fallback.
+                        if task_id.is_none() {
+                            if let Some(id) = result
+                                .get("taskId")
+                                .or_else(|| result.get("id"))
+                                .and_then(Value::as_str)
+                            {
+                                if !id.is_empty() {
+                                    task_id = Some(id.to_string());
+                                }
+                            }
+                        }
+                        // Append any text (artifact-update carries `artifact`,
+                        // status-update carries `status.message`, and a Task/Message
+                        // frame carries its own parts).
+                        for c in frame_text(&result) {
+                            if let Some(text) = dedup.push(&c) {
+                                on_output(&text);
+                            }
+                        }
+                        // Terminal state or explicit final flag closes the stream.
+                        if let Some(state) = task_state(&result) {
+                            if let Some(outcome) =
+                                terminal_outcome(&state, task_status_message(&result))
+                            {
+                                return StreamPhase::Terminal(outcome);
+                            }
+                        }
+                        if result.get("final").and_then(Value::as_bool) == Some(true) {
+                            return StreamPhase::Terminal(RemoteOutcome::Finished);
+                        }
+                    }
+                    Some(Err(e)) => {
+                        // Mid-stream error: degrade to polling if we know the task.
+                        match &task_id {
+                            Some(id) => return StreamPhase::Fallback(id.clone()),
+                            None => {
+                                return StreamPhase::Terminal(RemoteOutcome::Failed(e));
+                            }
+                        }
+                    }
+                    None => {
+                        // Stream ended without a terminal frame. Treat as done if
+                        // we streamed something; otherwise fall back / finish.
+                        return match &task_id {
+                            Some(id) => StreamPhase::Fallback(id.clone()),
+                            None => StreamPhase::Terminal(RemoteOutcome::Finished),
+                        };
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Text carried by a single stream frame (artifact-update, status-update, or a
+/// bare Task/Message frame).
+fn frame_text(result: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    // artifact-update: { artifact: { parts: [...] } }
+    if let Some(art) = result.get("artifact") {
+        out.extend(parts_text(art.get("parts")));
+    }
+    // status-update / Task: { status: { message: { parts } } } + artifacts
+    out.extend(task_text_chunks(result));
+    // bare Message frame: { parts: [...] }
+    if result.get("kind").and_then(Value::as_str) == Some("message") {
+        out.extend(message_text(result));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- card URL derivation ------------------------------------------------
+
+    #[test]
+    fn well_known_url_derived_from_base() {
+        assert_eq!(
+            well_known_card_url("https://agent.example.com"),
+            "https://agent.example.com/.well-known/agent-card.json"
+        );
+        assert_eq!(
+            well_known_card_url("https://agent.example.com/"),
+            "https://agent.example.com/.well-known/agent-card.json"
+        );
+    }
+
+    #[test]
+    fn well_known_url_accepts_full_card_url_verbatim() {
+        let full = "https://x.example.com/custom/agent-card.json";
+        assert_eq!(well_known_card_url(full), full);
+        let wk = "https://x.example.com/.well-known/agent-card.json";
+        assert_eq!(well_known_card_url(wk), wk);
+    }
+
+    // ---- card parse: both shapes -------------------------------------------
+
+    #[test]
+    fn parse_card_v03_shape() {
+        let v = json!({
+            "protocolVersion": "0.3.0",
+            "name": "V03 Agent",
+            "version": "1.0.0",
+            "url": "https://a.example.com/rpc",
+            "preferredTransport": "JSONRPC",
+            "capabilities": { "streaming": true },
+            "additionalInterfaces": [
+                { "url": "https://a.example.com/grpc", "transport": "GRPC" }
+            ],
+            "securitySchemes": { "bearer": { "type": "http", "scheme": "bearer" } },
+            "skills": [ { "id": "code", "name": "Coding" } ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        assert_eq!(card.name, "V03 Agent");
+        assert_eq!(card.version, "1.0.0");
+        assert!(card.streaming);
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://a.example.com/rpc"
+        );
+        assert_eq!(card.auth_schemes, vec!["http".to_string()]);
+        assert_eq!(card.skills.len(), 1);
+        assert_eq!(card.skills[0].id, "code");
+    }
+
+    #[test]
+    fn parse_card_v03_minimal_url_only_defaults_jsonrpc() {
+        // A minimal v0.3 card with just `url` (no preferredTransport) must
+        // resolve as JSONRPC per spec.
+        let v = json!({ "name": "Min", "version": "0.1", "url": "https://m.example.com/a2a" });
+        let card = parse_agent_card(&v).unwrap();
+        assert!(!card.streaming);
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://m.example.com/a2a"
+        );
+    }
+
+    #[test]
+    fn parse_card_v10_shape() {
+        let v = json!({
+            "protocolVersion": "1.0.0",
+            "name": "V10 Agent",
+            "version": "2.0.0",
+            "capabilities": { "streaming": false },
+            "supportedInterfaces": [
+                { "url": "https://b.example.com/grpc", "protocolBinding": "GRPC", "protocolVersion": "1.0.0" },
+                { "url": "https://b.example.com/rpc", "protocolBinding": "JSONRPC", "protocolVersion": "1.0.0" }
+            ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        assert_eq!(card.name, "V10 Agent");
+        assert!(!card.streaming);
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://b.example.com/rpc"
+        );
+    }
+
+    // ---- endpoint selection -------------------------------------------------
+
+    #[test]
+    fn endpoint_selection_honors_preferred_order() {
+        // Two JSONRPC interfaces: the first (preferred top-level url) wins.
+        let v = json!({
+            "name": "x", "version": "1",
+            "url": "https://first.example.com/rpc",
+            "preferredTransport": "JSONRPC",
+            "additionalInterfaces": [
+                { "url": "https://second.example.com/rpc", "transport": "JSONRPC" }
+            ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://first.example.com/rpc"
+        );
+    }
+
+    #[test]
+    fn endpoint_selection_errors_when_no_jsonrpc() {
+        let v = json!({
+            "name": "x", "version": "1",
+            "supportedInterfaces": [
+                { "url": "https://g.example.com", "protocolBinding": "GRPC" }
+            ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        let err = card.select_jsonrpc_endpoint().unwrap_err();
+        assert!(err.contains("JSON-RPC"));
+    }
+
+    #[test]
+    fn transport_token_normalizes_variants() {
+        assert!(is_jsonrpc("JSONRPC"));
+        assert!(is_jsonrpc("jsonrpc"));
+        assert!(is_jsonrpc("JSON-RPC"));
+        assert!(!is_jsonrpc("GRPC"));
+        assert!(!is_jsonrpc("HTTP+JSON"));
+    }
+
+    // ---- JSON-RPC envelope --------------------------------------------------
+
+    #[test]
+    fn envelope_error_wins_over_result() {
+        let v = json!({ "jsonrpc": "2.0", "id": "1",
+            "error": { "code": -32001, "message": "Task not found" },
+            "result": null });
+        let err = parse_jsonrpc_envelope(&v).unwrap_err();
+        assert_eq!(err, "-32001: Task not found");
+    }
+
+    #[test]
+    fn envelope_returns_result() {
+        let v = json!({ "jsonrpc": "2.0", "id": "1", "result": { "kind": "task", "id": "t1" } });
+        let r = parse_jsonrpc_envelope(&v).unwrap();
+        assert_eq!(r.get("id").unwrap(), "t1");
+    }
+
+    #[test]
+    fn envelope_missing_both_errors() {
+        let v = json!({ "jsonrpc": "2.0", "id": "1" });
+        assert!(parse_jsonrpc_envelope(&v).is_err());
+    }
+
+    // ---- send-result dispatch ----------------------------------------------
+
+    #[test]
+    fn dispatch_direct_message() {
+        let result = json!({
+            "kind": "message",
+            "role": "agent",
+            "parts": [ { "kind": "text", "text": "hello there" } ]
+        });
+        assert_eq!(
+            dispatch_send_result(&result),
+            SendDispatch::DirectMessage(vec!["hello there".to_string()])
+        );
+    }
+
+    #[test]
+    fn dispatch_task_with_id() {
+        let result = json!({
+            "kind": "task",
+            "id": "task-42",
+            "status": { "state": "working" }
+        });
+        assert_eq!(
+            dispatch_send_result(&result),
+            SendDispatch::Task {
+                id: "task-42".to_string(),
+                initial_text: vec![]
+            }
+        );
+    }
+
+    #[test]
+    fn dispatch_task_without_kind_via_structure() {
+        // No `kind` but has status+id → task.
+        let result = json!({ "id": "t9", "status": { "state": "submitted" } });
+        assert!(matches!(
+            dispatch_send_result(&result),
+            SendDispatch::Task { .. }
+        ));
+    }
+
+    #[test]
+    fn dispatch_task_without_id_is_unusable() {
+        let result = json!({ "kind": "task", "status": { "state": "working" } });
+        assert_eq!(dispatch_send_result(&result), SendDispatch::UnusableTask);
+    }
+
+    // ---- part / task text ---------------------------------------------------
+
+    #[test]
+    fn non_text_parts_are_summarized() {
+        let file = json!({ "kind": "file", "file": { "name": "out.txt" } });
+        assert_eq!(part_to_text(&file), Some("[file: out.txt]".to_string()));
+        let data = json!({ "kind": "data", "data": { "x": 1 } });
+        assert_eq!(part_to_text(&data), Some("[data]".to_string()));
+        let text = json!({ "kind": "text", "text": "hi" });
+        assert_eq!(part_to_text(&text), Some("hi".to_string()));
+    }
+
+    #[test]
+    fn task_text_gathers_status_and_artifacts() {
+        let task = json!({
+            "id": "t",
+            "status": { "state": "working", "message": { "parts": [ { "kind": "text", "text": "step 1" } ] } },
+            "artifacts": [
+                { "parts": [ { "kind": "text", "text": "result A" } ] },
+                { "parts": [ { "kind": "text", "text": "result B" } ] }
+            ]
+        });
+        assert_eq!(
+            task_text_chunks(&task),
+            vec![
+                "step 1".to_string(),
+                "result A".to_string(),
+                "result B".to_string()
+            ]
+        );
+    }
+
+    // ---- state mapping table -----------------------------------------------
+
+    #[test]
+    fn state_mapping_table() {
+        assert_eq!(classify_state("submitted", None), StateClass::NonTerminal);
+        assert_eq!(classify_state("working", None), StateClass::NonTerminal);
+        assert_eq!(classify_state("completed", None), StateClass::Finished);
+        assert_eq!(
+            classify_state("failed", Some("boom".into())),
+            StateClass::Failed(Some("boom".into()))
+        );
+        assert_eq!(classify_state("rejected", None), StateClass::Failed(None));
+        assert_eq!(classify_state("canceled", None), StateClass::Stopped);
+        assert_eq!(
+            classify_state("input-required", None),
+            StateClass::NeedsInput
+        );
+        assert_eq!(
+            classify_state("auth-required", None),
+            StateClass::NeedsInput
+        );
+        assert_eq!(classify_state("weird", None), StateClass::Unknown);
+    }
+
+    #[test]
+    fn terminal_outcome_folds_needs_input_to_failure() {
+        assert_eq!(terminal_outcome("submitted", None), None);
+        assert_eq!(
+            terminal_outcome("completed", None),
+            Some(RemoteOutcome::Finished)
+        );
+        assert_eq!(
+            terminal_outcome("canceled", None),
+            Some(RemoteOutcome::Stopped)
+        );
+        match terminal_outcome("input-required", None) {
+            Some(RemoteOutcome::Failed(m)) => assert!(m.contains("multi-turn")),
+            other => panic!("unexpected: {other:?}"),
+        }
+        match terminal_outcome("failed", Some("disk full".into())) {
+            Some(RemoteOutcome::Failed(m)) => assert!(m.contains("disk full")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    // ---- dedupe -------------------------------------------------------------
+
+    #[test]
+    fn dedup_emits_each_chunk_once() {
+        let mut d = TextDedup::new();
+        assert_eq!(d.push("a"), Some("a".to_string()));
+        assert_eq!(d.push("a"), None);
+        assert_eq!(d.push("b"), Some("b".to_string()));
+        assert_eq!(d.push(""), None);
+    }
+
+    // ---- SSE parser ---------------------------------------------------------
+
+    #[test]
+    fn sse_single_frame() {
+        let mut p = SseParser::new();
+        let out = p.feed("data: {\"a\":1}\n\n");
+        assert_eq!(out, vec!["{\"a\":1}".to_string()]);
+    }
+
+    #[test]
+    fn sse_multiline_data_joined_with_newline() {
+        let mut p = SseParser::new();
+        let out = p.feed("data: line1\ndata: line2\n\n");
+        assert_eq!(out, vec!["line1\nline2".to_string()]);
+    }
+
+    #[test]
+    fn sse_comments_and_crlf() {
+        let mut p = SseParser::new();
+        // `:` comment line is ignored; CRLF line endings are handled.
+        let out = p.feed(": keep-alive\r\ndata: {\"ok\":true}\r\n\r\n");
+        assert_eq!(out, vec!["{\"ok\":true}".to_string()]);
+    }
+
+    #[test]
+    fn sse_event_split_across_chunks() {
+        let mut p = SseParser::new();
+        assert!(p.feed("data: {\"par").is_empty());
+        assert!(p.feed("t\":1}").is_empty());
+        let out = p.feed("\n\n");
+        assert_eq!(out, vec!["{\"part\":1}".to_string()]);
+    }
+
+    #[test]
+    fn sse_two_frames_one_chunk() {
+        let mut p = SseParser::new();
+        let out = p.feed("data: a\n\ndata: b\n\n");
+        assert_eq!(out, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn sse_garbage_is_returned_and_parses_none() {
+        // The parser returns the payload even if it's not JSON — the consumer's
+        // serde parse then drops it. Here we assert the raw payload comes through.
+        let mut p = SseParser::new();
+        let out = p.feed("data: not json\n\n");
+        assert_eq!(out, vec!["not json".to_string()]);
+        assert!(serde_json::from_str::<Value>(&out[0]).is_err());
+    }
+
+    #[test]
+    fn request_ids_are_unique_and_shaped() {
+        let a = new_request_id();
+        let b = new_request_id();
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 36);
+        assert_eq!(a.chars().filter(|c| *c == '-').count(), 4);
+    }
+
+    // ---- driver protocol loop against a MOCK transport (no network) ---------
+
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
+
+    /// A scriptable, no-network [`A2aTransport`] for driver-flow tests. `call`
+    /// dispatches on method; `tasks/get` walks a queue (repeating its last entry
+    /// so a poll loop can spin), `tasks/cancel` is counted.
+    struct MockTransport {
+        send_result: Mutex<Option<Result<Value, String>>>,
+        get_results: Mutex<VecDeque<Result<Value, String>>>,
+        stream_frames: Mutex<Option<Vec<Result<Value, String>>>>,
+        cancel_calls: AtomicUsize,
+        get_calls: AtomicUsize,
+    }
+
+    impl MockTransport {
+        fn new() -> Self {
+            Self {
+                send_result: Mutex::new(None),
+                get_results: Mutex::new(VecDeque::new()),
+                stream_frames: Mutex::new(None),
+                cancel_calls: AtomicUsize::new(0),
+                get_calls: AtomicUsize::new(0),
+            }
+        }
+        fn with_send(self, r: Result<Value, String>) -> Self {
+            *self.send_result.lock().unwrap() = Some(r);
+            self
+        }
+        fn with_gets(self, rs: Vec<Result<Value, String>>) -> Self {
+            *self.get_results.lock().unwrap() = rs.into();
+            self
+        }
+        fn with_stream(self, frames: Vec<Result<Value, String>>) -> Self {
+            *self.stream_frames.lock().unwrap() = Some(frames);
+            self
+        }
+    }
+
+    impl A2aTransport for MockTransport {
+        fn fetch_card(
+            &self,
+            _url: String,
+            _token: Option<String>,
+        ) -> impl std::future::Future<Output = Result<Value, String>> + Send {
+            let card = json!({ "name": "Mock", "version": "1", "url": "https://mock/rpc" });
+            async move { Ok(card) }
+        }
+
+        fn call(
+            &self,
+            _endpoint: String,
+            _token: Option<String>,
+            method: String,
+            _params: Value,
+        ) -> impl std::future::Future<Output = Result<Value, String>> + Send {
+            let result = if method == METHOD_MESSAGE_SEND {
+                self.send_result
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap_or_else(|| Err("no send scripted".to_string()))
+            } else if method == METHOD_TASKS_GET {
+                self.get_calls.fetch_add(1, Ordering::Relaxed);
+                let mut q = self.get_results.lock().unwrap();
+                if q.len() > 1 {
+                    q.pop_front().unwrap()
+                } else {
+                    q.front()
+                        .cloned()
+                        .unwrap_or_else(|| Err("no get scripted".to_string()))
+                }
+            } else if method == METHOD_TASKS_CANCEL {
+                self.cancel_calls.fetch_add(1, Ordering::Relaxed);
+                Ok(json!({}))
+            } else {
+                Err(format!("unexpected method {method}"))
+            };
+            async move { result }
+        }
+
+        fn stream(
+            &self,
+            _endpoint: String,
+            _token: Option<String>,
+            _method: String,
+            _params: Value,
+        ) -> impl std::future::Future<Output = Result<A2aStream, String>> + Send {
+            let frames = self.stream_frames.lock().unwrap().clone();
+            async move {
+                match frames {
+                    Some(fs) => {
+                        let s = futures_util::stream::iter(fs);
+                        Ok(Box::pin(s) as A2aStream)
+                    }
+                    None => Err("no stream scripted".to_string()),
+                }
+            }
+        }
+    }
+
+    /// Run a future to completion on a current-thread runtime with the time
+    /// driver enabled (the repo enables the tokio `rt`+`time` features but uses
+    /// no `#[tokio::test]`, so we build the runtime explicitly).
+    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    fn tiny() -> (Duration, Duration) {
+        (Duration::from_millis(1), Duration::from_secs(60))
+    }
+
+    #[test]
+    fn driver_direct_message_happy_path() {
+        block_on(async {
+            let t = MockTransport::new().with_send(Ok(json!({
+                "kind": "message",
+                "parts": [ { "kind": "text", "text": "all done" } ]
+            })));
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "do it",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Finished);
+            assert_eq!(out, vec!["all done".to_string()]);
+        });
+    }
+
+    #[test]
+    fn driver_task_poll_until_completed() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "submitted" } }),
+                ))
+                .with_gets(vec![
+                    Ok(json!({ "id": "t1", "status": { "state": "working" } })),
+                    Ok(json!({
+                        "id": "t1",
+                        "status": { "state": "completed" },
+                        "artifacts": [ { "parts": [ { "kind": "text", "text": "final answer" } ] } ]
+                    })),
+                ]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Finished);
+            assert_eq!(out, vec!["final answer".to_string()]);
+            assert!(t.get_calls.load(Ordering::Relaxed) >= 2);
+        });
+    }
+
+    #[test]
+    fn driver_task_failed_includes_server_message() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                .with_gets(vec![Ok(json!({
+                    "id": "t1",
+                    "status": {
+                        "state": "failed",
+                        "message": { "parts": [ { "kind": "text", "text": "out of credits" } ] }
+                    }
+                }))]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("out of credits"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_cancel_mid_poll_calls_tasks_cancel_and_stops() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                // Never terminal — the poll would spin until we cancel.
+                .with_gets(vec![Ok(
+                    json!({ "id": "t1", "status": { "state": "working" } }),
+                )]);
+            let (tx, mut rx) = mpsc::unbounded_channel::<()>();
+            tx.send(()).unwrap(); // request a stop before the first poll wait
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Stopped);
+            assert_eq!(t.cancel_calls.load(Ordering::Relaxed), 1);
+        });
+    }
+
+    #[test]
+    fn driver_input_required_is_actionable_failure() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                .with_gets(vec![Ok(
+                    json!({ "id": "t1", "status": { "state": "input-required" } }),
+                )]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("multi-turn"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_poll_cap_times_out() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                .with_gets(vec![Ok(
+                    json!({ "id": "t1", "status": { "state": "working" } }),
+                )]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            // Zero cap: the first poll wait immediately exceeds the deadline.
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                Duration::from_millis(1),
+                Duration::from_millis(0),
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("timed out"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_send_jsonrpc_error_fails() {
+        block_on(async {
+            let t = MockTransport::new().with_send(Err("-32600: Invalid Request".to_string()));
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("Invalid Request"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_streaming_happy_path() {
+        block_on(async {
+            let t = MockTransport::new().with_stream(vec![
+                Ok(json!({
+                    "kind": "artifact-update",
+                    "taskId": "t1",
+                    "artifact": { "parts": [ { "kind": "text", "text": "chunk one" } ] }
+                })),
+                Ok(json!({
+                    "kind": "status-update",
+                    "taskId": "t1",
+                    "status": { "state": "completed" },
+                    "final": true
+                })),
+            ]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                true,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Finished);
+            assert_eq!(out, vec!["chunk one".to_string()]);
+        });
+    }
+}

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1313,31 +1313,38 @@ pub(crate) async fn finish_dictation(
         .map(|m| m.kind == AiModeKind::Command)
         .unwrap_or(false);
 
-    // Flow OS increment 2: a CLI agent does NOT run the persona-LLM transform or
-    // inject anything — it drives a real coding-agent subprocess. Hand the
-    // transcript to the AgentRunManager (which spawns the process + a detached
-    // streaming task and returns at once) and RETURN IMMEDIATELY so the
+    // Flow OS increment 2/3: a CLI or REMOTE (A2A) agent does NOT run the
+    // persona-LLM transform or inject anything — it drives a real coding-agent
+    // subprocess (Cli) or a remote A2A server (Remote) behind the SAME run seam.
+    // Hand the transcript to the AgentRunManager (which registers the run + a
+    // detached driver task and returns at once) and RETURN IMMEDIATELY so the
     // coordinator's Processing stage ends promptly and dictation is never
     // blocked by a long agent run. Prompt agents and normal dictation fall
     // through to the unchanged increment-1 path below.
     if let Some(agent) = agent.as_ref() {
-        if agent.kind == crate::settings::AgentKind::Cli {
+        use crate::settings::AgentKind;
+        if agent.kind == AgentKind::Cli || agent.kind == AgentKind::Remote {
+            let kind_label = if agent.kind == AgentKind::Remote {
+                "remote"
+            } else {
+                "CLI"
+            };
             let instruction = raw_text.trim().to_string();
             if instruction.is_empty() {
                 debug!(
-                    "CLI agent '{}' triggered with an empty transcript; skipping run",
-                    agent.id
+                    "{} agent '{}' triggered with an empty transcript; skipping run",
+                    kind_label, agent.id
                 );
             } else if let Some(mgr) = ah.try_state::<Arc<AgentRunManager>>() {
                 let run_id = mgr.inner().start(&ah, agent.clone(), instruction);
                 debug!(
-                    "Started CLI agent run '{}' for agent '{}' (project: '{}')",
-                    run_id, agent.id, agent.project_path
+                    "Started {} agent run '{}' for agent '{}'",
+                    kind_label, run_id, agent.id
                 );
             } else {
                 error!(
-                    "AgentRunManager not initialized; cannot start CLI agent '{}'",
-                    agent.id
+                    "AgentRunManager not initialized; cannot start {} agent '{}'",
+                    kind_label, agent.id
                 );
             }
             utils::hide_recording_overlay(&ah);
@@ -2253,6 +2260,11 @@ mod tests {
             project_path: String::new(),
             output_sinks: vec![AgentOutputSink::Panel],
             prompt_via: PromptDelivery::Stdin,
+            remote_url: String::new(),
+            remote_endpoint: String::new(),
+            remote_card_name: String::new(),
+            remote_card_version: String::new(),
+            remote_streaming: false,
         }
     }
 

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -210,6 +210,11 @@ mod tests {
             project_path: String::new(),
             output_sinks: vec![AgentOutputSink::Panel],
             prompt_via: PromptDelivery::Stdin,
+            remote_url: String::new(),
+            remote_endpoint: String::new(),
+            remote_card_name: String::new(),
+            remote_card_version: String::new(),
+            remote_streaming: false,
         }
     }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod backends;
 pub mod history;
 pub mod meetings;
 pub mod models;
+pub mod remote_agents;
 pub mod service;
 pub mod transcription;
 

--- a/src-tauri/src/commands/remote_agents.rs
+++ b/src-tauri/src/commands/remote_agents.rs
@@ -1,0 +1,140 @@
+//! Flow OS increment 3 — commands for **remote (A2A) agents**.
+//!
+//! These manage the A2A-specific lifecycle that the generic agent commands
+//! (`create_agent`/`update_agent`/`delete_agent` in `commands::agents`) don't
+//! cover: fetching + resolving an agent card, and a lightweight reachability
+//! test. Everything else (create/update/delete, hotkey binding, the per-agent
+//! keyring token via `set_api_key("agent", id, …)`) is reused unchanged.
+//!
+//! The token lives in the OS keyring (scope `"agent"`, account = agent id) and
+//! is never written to the settings store; `delete_agent` already cleans it up.
+
+use tauri::AppHandle;
+
+use crate::a2a::{self, A2aTransport, AgentCardSummary, HttpA2aTransport};
+use crate::settings::{self, AgentDefinition};
+
+/// Map a raw fetch/transport error into a friendly, user-facing message
+/// (mirrors the `service.rs` status-mapping pattern). The `no-JSON-RPC` and
+/// `not-A2A` cases already carry clear messages and pass through.
+fn friendly_card_error(e: &str) -> String {
+    if e.contains("HTTP 401") {
+        "This agent needs a token. Add one in the token field below, then fetch again.".to_string()
+    } else if e.contains("HTTP 404") {
+        "No agent card was found at that URL. Check the address.".to_string()
+    } else if e.starts_with("Could not reach the agent")
+        || e.contains("JSON-RPC")
+        || e.contains("not a JSON object")
+        || e.contains("valid JSON")
+    {
+        // These already carry a clear, user-facing message — surface verbatim.
+        e.to_string()
+    } else {
+        format!("Couldn't read the agent card: {e}")
+    }
+}
+
+/// Shared core: fetch the card (with 401→token retry inside the transport),
+/// parse it, resolve the JSON-RPC endpoint, and return the parsed card + endpoint.
+async fn fetch_and_resolve<T: A2aTransport>(
+    transport: &T,
+    agent: &AgentDefinition,
+    token: Option<String>,
+) -> Result<(a2a::AgentCard, String), String> {
+    if agent.remote_url.trim().is_empty() {
+        return Err("Enter the agent's URL first.".to_string());
+    }
+    let url = a2a::well_known_card_url(&agent.remote_url);
+    let card_json = transport
+        .fetch_card(url, token)
+        .await
+        .map_err(|e| friendly_card_error(&e))?;
+    let card = a2a::parse_agent_card(&card_json).map_err(|e| friendly_card_error(&e))?;
+    let endpoint = card.select_jsonrpc_endpoint()?;
+    Ok((card, endpoint))
+}
+
+fn find_agent(app: &AppHandle, id: &str) -> Result<AgentDefinition, String> {
+    settings::get_settings(app)
+        .agents
+        .into_iter()
+        .find(|a| a.id == id)
+        .ok_or_else(|| format!("Agent '{id}' not found"))
+}
+
+/// Fetch and resolve a remote agent's card, PERSIST the resolved endpoint +
+/// display metadata onto the agent, and return a summary for the UI. This is the
+/// settings "Fetch card" button.
+#[tauri::command]
+#[specta::specta]
+pub async fn fetch_remote_agent_card(
+    app: AppHandle,
+    agent_id: String,
+) -> Result<AgentCardSummary, String> {
+    let agent = find_agent(&app, &agent_id)?;
+    let token = crate::keychain::get_api_key("agent", &agent_id);
+    let transport = HttpA2aTransport::new();
+
+    let (card, endpoint) = fetch_and_resolve(&transport, &agent, token).await?;
+    let summary = card.summary(endpoint.clone());
+
+    // Persist the resolved endpoint + cached display metadata onto the agent so
+    // a run doesn't have to re-fetch. Re-read to avoid clobbering a concurrent
+    // edit to a different field.
+    let mut current = settings::get_settings(&app);
+    if let Some(a) = current.agents.iter_mut().find(|a| a.id == agent_id) {
+        a.remote_endpoint = endpoint;
+        a.remote_card_name = card.name.clone();
+        a.remote_card_version = card.version.clone();
+        a.remote_streaming = card.streaming;
+        settings::write_settings(&app, current);
+    }
+
+    Ok(summary)
+}
+
+/// Lightweight reachability test: re-fetch the card (with the 401→token retry).
+/// Deliberately does NOT send a real message — that could cost money or trigger
+/// real work on the user's server. Returns the resolved endpoint on success.
+#[tauri::command]
+#[specta::specta]
+pub async fn test_remote_agent(app: AppHandle, agent_id: String) -> Result<String, String> {
+    let agent = find_agent(&app, &agent_id)?;
+    let token = crate::keychain::get_api_key("agent", &agent_id);
+    let transport = HttpA2aTransport::new();
+    let (_card, endpoint) = fetch_and_resolve(&transport, &agent, token).await?;
+    Ok(endpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn friendly_error_maps_401_to_token_hint() {
+        let msg = friendly_card_error("HTTP 401");
+        assert!(msg.contains("token"));
+    }
+
+    #[test]
+    fn friendly_error_maps_404() {
+        assert!(friendly_card_error("HTTP 404").contains("Check the address"));
+    }
+
+    #[test]
+    fn friendly_error_passes_through_no_jsonrpc() {
+        let raw = "This agent doesn't offer a JSON-RPC interface. OpenFlow only speaks the A2A JSON-RPC binding.";
+        assert_eq!(friendly_card_error(raw), raw);
+    }
+
+    #[test]
+    fn friendly_error_passes_through_unreachable() {
+        let raw = "Could not reach the agent: connection refused";
+        assert_eq!(friendly_card_error(raw), raw);
+    }
+
+    #[test]
+    fn friendly_error_wraps_unknown() {
+        assert!(friendly_card_error("weird thing").starts_with("Couldn't read the agent card"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod a2a;
 mod actions;
 mod active_app;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -695,6 +696,8 @@ pub fn run(cli_args: CliArgs) {
             commands::agents::update_agent,
             commands::agents::delete_agent,
             commands::agents::test_agent,
+            commands::remote_agents::fetch_remote_agent_card,
+            commands::remote_agents::test_remote_agent,
             commands::ai_modes::create_ai_mode,
             commands::ai_modes::update_ai_mode,
             commands::ai_modes::delete_ai_mode,

--- a/src-tauri/src/managers/agent_run.rs
+++ b/src-tauri/src/managers/agent_run.rs
@@ -27,7 +27,8 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
 
-use crate::settings::{AgentCliType, AgentDefinition, AgentOutputSink, PromptDelivery};
+use crate::a2a::{self, A2aTransport, HttpA2aTransport, RemoteOutcome};
+use crate::settings::{AgentCliType, AgentDefinition, AgentKind, AgentOutputSink, PromptDelivery};
 
 /// Cap on the rolling per-run output buffer. Enough to keep a useful tail for
 /// the panel and the written file, bounded so a chatty run can't grow memory
@@ -291,21 +292,36 @@ impl AgentRunManager {
         let binary = agent.binary_path.clone();
         let run_id_task = run_id.clone();
 
-        // Detached task: spawn, stream, finalize. Uses the app's async runtime.
-        tauri::async_runtime::spawn(async move {
-            manager
-                .drive_run(
-                    app,
-                    run_id_task,
-                    agent,
-                    binary,
-                    argv,
-                    cwd,
-                    stdin_input,
-                    kill_rx,
-                )
-                .await;
-        });
+        // Detached task: drive to completion, stream, finalize. Uses the app's
+        // async runtime. The driver seam: a `Remote` (A2A) agent takes the
+        // RemoteDriver; every other kind takes the CLI subprocess driver. The
+        // registry entry, run_id and kill wiring above are identical for both —
+        // the run panel (which only subscribes to the two events) needs nothing.
+        match agent.kind {
+            AgentKind::Remote => {
+                tauri::async_runtime::spawn(async move {
+                    manager
+                        .drive_remote_run(app, run_id_task, agent, instruction, kill_rx)
+                        .await;
+                });
+            }
+            _ => {
+                tauri::async_runtime::spawn(async move {
+                    manager
+                        .drive_run(
+                            app,
+                            run_id_task,
+                            agent,
+                            binary,
+                            argv,
+                            cwd,
+                            stdin_input,
+                            kill_rx,
+                        )
+                        .await;
+                });
+            }
+        }
 
         run_id
     }
@@ -448,6 +464,131 @@ impl AgentRunManager {
         }
 
         self.finalize(&app, &run_id, &agent, status, started).await;
+    }
+
+    /// Drive a **remote (A2A) agent** run behind the SAME run seam as
+    /// `drive_run`: it reuses `append_output` / the `AgentRunOutput` event /
+    /// `finalize` / the kill channel / `AgentRunStatus` verbatim, so the run
+    /// panel needs zero changes. The protocol itself lives in `crate::a2a`
+    /// (`run_remote_protocol`), which is unit-tested against a mock transport
+    /// with no network — this method is the thin glue (endpoint resolution,
+    /// header line, live-output plumbing, status mapping).
+    async fn drive_remote_run(
+        self: Arc<Self>,
+        app: AppHandle,
+        run_id: String,
+        agent: AgentDefinition,
+        instruction: String,
+        mut kill_rx: mpsc::UnboundedReceiver<()>,
+    ) {
+        let started = std::time::Instant::now();
+        let transport = HttpA2aTransport::new();
+        // Per-agent bearer token from the OS keyring (scope "agent", account =
+        // agent id). Never in the settings store; absent for a public agent.
+        let token = crate::keychain::get_api_key("agent", &agent.id);
+
+        // 1. Resolve the JSON-RPC endpoint. Cached on the agent after a UI card
+        //    fetch; if empty we attempt one fetch+resolve here, and a failure is
+        //    an actionable Failed (raw English in the stream, like CLI output).
+        let endpoint = match self
+            .resolve_remote_endpoint(&transport, &agent, token.clone())
+            .await
+        {
+            Ok(ep) => ep,
+            Err(e) => {
+                self.emit_line(&app, &run_id, &e);
+                self.finalize(
+                    &app,
+                    &run_id,
+                    &agent,
+                    RunStatus::Failed { error: e },
+                    started,
+                )
+                .await;
+                return;
+            }
+        };
+
+        // 2. Header line so the panel shows where this is going.
+        let name = if agent.remote_card_name.trim().is_empty() {
+            agent.remote_url.clone()
+        } else {
+            agent.remote_card_name.clone()
+        };
+        self.emit_line(&app, &run_id, &format!("→ {name} @ {endpoint}"));
+
+        // 3. Run the protocol, streaming each new text chunk live into the panel.
+        let manager = Arc::clone(&self);
+        let app_out = app.clone();
+        let run_id_out = run_id.clone();
+        let mut on_output = move |chunk: &str| {
+            manager.append_output(&run_id_out, chunk);
+            let _ = AgentRunOutput {
+                run_id: run_id_out.clone(),
+                chunk: chunk.to_string(),
+            }
+            .emit(&app_out);
+        };
+
+        let outcome = a2a::run_remote_protocol(
+            &transport,
+            &endpoint,
+            token,
+            &instruction,
+            agent.remote_streaming,
+            &mut kill_rx,
+            &mut on_output,
+            a2a::POLL_INTERVAL,
+            a2a::POLL_CAP,
+        )
+        .await;
+        drop(on_output);
+
+        let status = match outcome {
+            RemoteOutcome::Finished => RunStatus::Finished { code: 0 },
+            RemoteOutcome::Failed(error) => RunStatus::Failed { error },
+            RemoteOutcome::Stopped => RunStatus::Stopped,
+        };
+        self.finalize(&app, &run_id, &agent, status, started).await;
+    }
+
+    /// Resolve a remote agent's JSON-RPC endpoint: the cached `remote_endpoint`
+    /// when present, otherwise one card fetch+resolve (with an actionable error
+    /// pointing the user at the settings "Fetch card" button).
+    async fn resolve_remote_endpoint<T: A2aTransport>(
+        &self,
+        transport: &T,
+        agent: &AgentDefinition,
+        token: Option<String>,
+    ) -> Result<String, String> {
+        if !agent.remote_endpoint.trim().is_empty() {
+            return Ok(agent.remote_endpoint.clone());
+        }
+        if agent.remote_url.trim().is_empty() {
+            return Err(
+                "This remote agent has no URL. Open its settings, enter the \
+                        agent URL, and Fetch the card first."
+                    .to_string(),
+            );
+        }
+        let url = a2a::well_known_card_url(&agent.remote_url);
+        let card_json = transport.fetch_card(url, token).await.map_err(|e| {
+            format!("Couldn't fetch the agent card ({e}). Fetch the agent card in settings first.")
+        })?;
+        let card = a2a::parse_agent_card(&card_json)?;
+        card.select_jsonrpc_endpoint()
+    }
+
+    /// Append a plain line to the run buffer AND emit it as an `agent-run-output`
+    /// event (the header line and remote-driver error lines flow through here —
+    /// like CLI subprocess output, the remote stream is raw, un-i18n'd text).
+    fn emit_line(&self, app: &AppHandle, run_id: &str, line: &str) {
+        self.append_output(run_id, line);
+        let _ = AgentRunOutput {
+            run_id: run_id.to_string(),
+            chunk: line.to_string(),
+        }
+        .emit(app);
     }
 
     /// Set the terminal status, emit `agent-run-status`, and run the output sinks.

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -112,13 +112,17 @@ impl Default for AgentOutputMode {
 /// Flow OS increment 2 — what KIND of agent this is. `Prompt` is the increment-1
 /// behavior (dictation routed through a persona LLM before injection). `Cli`
 /// drives a REAL local coding-agent binary (Claude Code, Codex, …) as a
-/// subprocess in a chosen project folder. Defaults to `Prompt` so every agent
-/// stored before this field existed stays a prompt agent, byte-for-byte.
+/// subprocess in a chosen project folder. `Remote` (increment 3) drives a
+/// spec-compliant **A2A** server the user points OpenFlow at (their VPS agent, a
+/// hosted flow, any endpoint) over the A2A JSON-RPC binding. Defaults to
+/// `Prompt` so every agent stored before this field existed stays a prompt
+/// agent, byte-for-byte.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentKind {
     Prompt,
     Cli,
+    Remote,
 }
 
 impl Default for AgentKind {
@@ -332,6 +336,26 @@ pub struct AgentDefinition {
     /// How the instruction reaches the CLI. `Stdin` (default) or `Arg`.
     #[serde(default)]
     pub prompt_via: PromptDelivery,
+
+    // ---- Flow OS increment 3: Remote agents (A2A) ----
+    /// The A2A agent's base URL as entered by the user. We derive
+    /// `<origin>/.well-known/agent-card.json`; a full `…/agent-card.json` URL is
+    /// accepted verbatim. Only meaningful when `kind == Remote`.
+    #[serde(default)]
+    pub remote_url: String,
+    /// The resolved JSON-RPC endpoint URL from the agent card, cached at fetch
+    /// time. Empty until the first successful `fetch_remote_agent_card`.
+    #[serde(default)]
+    pub remote_endpoint: String,
+    /// Display name cached from the agent card.
+    #[serde(default)]
+    pub remote_card_name: String,
+    /// Version cached from the agent card.
+    #[serde(default)]
+    pub remote_card_version: String,
+    /// Card `capabilities.streaming`, cached — whether we may use `message/stream`.
+    #[serde(default)]
+    pub remote_streaming: bool,
 }
 
 /// What an AI Mode does with the raw transcript before it reaches the cursor.
@@ -2285,6 +2309,44 @@ mod tests {
         assert!(agent.project_path.is_empty());
         assert_eq!(agent.output_sinks, vec![AgentOutputSink::Panel]);
         assert_eq!(agent.prompt_via, PromptDelivery::Stdin);
+        // Increment-3 remote fields must also default to empty/false so a
+        // pre-remote store stays byte-for-byte a Prompt agent.
+        assert!(agent.remote_url.is_empty());
+        assert!(agent.remote_endpoint.is_empty());
+        assert!(agent.remote_card_name.is_empty());
+        assert!(agent.remote_card_version.is_empty());
+        assert!(!agent.remote_streaming);
+    }
+
+    #[test]
+    fn remote_agent_round_trips_through_serde() {
+        // A remote (A2A) agent's new fields must survive a serialize→deserialize
+        // cycle (this is what create_agent/update_agent persist through), and a
+        // `kind:"remote"` value must map to AgentKind::Remote.
+        let raw = serde_json::json!({
+            "id": "vps",
+            "name": "My VPS Agent",
+            "enabled": true,
+            "binding_id": "agent:vps",
+            "provider_id": "",
+            "kind": "remote",
+            "remote_url": "https://agent.example.com",
+            "remote_endpoint": "https://agent.example.com/a2a/v1",
+            "remote_card_name": "Example Agent",
+            "remote_card_version": "1.2.3",
+            "remote_streaming": true,
+            "output_mode": "inject"
+        });
+        let agent: AgentDefinition = serde_json::from_value(raw).unwrap();
+        assert_eq!(agent.kind, AgentKind::Remote);
+        assert_eq!(agent.remote_url, "https://agent.example.com");
+        assert_eq!(agent.remote_endpoint, "https://agent.example.com/a2a/v1");
+        assert_eq!(agent.remote_card_name, "Example Agent");
+        assert_eq!(agent.remote_card_version, "1.2.3");
+        assert!(agent.remote_streaming);
+        // CLI fields stay at their defaults for a remote agent.
+        assert!(agent.cli_type.is_none());
+        assert!(agent.binary_path.is_empty());
     }
 
     #[test]

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -943,6 +943,32 @@ async testAgent(id: string, sampleText: string) : Promise<Result<AgentTestResult
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Fetch and resolve a remote agent's card, PERSIST the resolved endpoint +
+ * display metadata onto the agent, and return a summary for the UI. This is the
+ * settings "Fetch card" button.
+ */
+async fetchRemoteAgentCard(agentId: string) : Promise<Result<AgentCardSummary, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("fetch_remote_agent_card", { agentId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Lightweight reachability test: re-fetch the card (with the 401→token retry).
+ * Deliberately does NOT send a real message — that could cost money or trigger
+ * real work on the user's server. Returns the resolved endpoint on success.
+ */
+async testRemoteAgent(agentId: string) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("test_remote_agent", { agentId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async createAiMode(mode: AiMode) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_ai_mode", { mode }) };
@@ -1633,6 +1659,16 @@ export type AgentBinaryTest = { ok: boolean; output: string;
  * message (e.g. a broken Codex install). `None` for ordinary output.
  */
 hint: AgentBinaryHint | null }
+export type AgentCardSkill = { id: string; name: string }
+/**
+ * UI-facing summary returned by `fetch_remote_agent_card` / persisted on the agent.
+ */
+export type AgentCardSummary = { name: string; version: string; streaming: boolean; 
+/**
+ * The resolved JSON-RPC endpoint (empty only if selection somehow failed —
+ * callers error out before building a summary in that case).
+ */
+endpoint: string; auth_schemes: string[]; skills: AgentCardSkill[] }
 /**
  * Which local coding-agent CLI a `Cli` agent drives. Selects the prefilled
  * invocation template (see `default_command_template_for`). `Custom` is a
@@ -1697,15 +1733,41 @@ output_sinks?: AgentOutputSink[];
 /**
  * How the instruction reaches the CLI. `Stdin` (default) or `Arg`.
  */
-prompt_via?: PromptDelivery }
+prompt_via?: PromptDelivery; 
+/**
+ * The A2A agent's base URL as entered by the user. We derive
+ * `<origin>/.well-known/agent-card.json`; a full `…/agent-card.json` URL is
+ * accepted verbatim. Only meaningful when `kind == Remote`.
+ */
+remote_url?: string; 
+/**
+ * The resolved JSON-RPC endpoint URL from the agent card, cached at fetch
+ * time. Empty until the first successful `fetch_remote_agent_card`.
+ */
+remote_endpoint?: string; 
+/**
+ * Display name cached from the agent card.
+ */
+remote_card_name?: string; 
+/**
+ * Version cached from the agent card.
+ */
+remote_card_version?: string; 
+/**
+ * Card `capabilities.streaming`, cached — whether we may use `message/stream`.
+ */
+remote_streaming?: boolean }
 /**
  * Flow OS increment 2 — what KIND of agent this is. `Prompt` is the increment-1
  * behavior (dictation routed through a persona LLM before injection). `Cli`
  * drives a REAL local coding-agent binary (Claude Code, Codex, …) as a
- * subprocess in a chosen project folder. Defaults to `Prompt` so every agent
- * stored before this field existed stays a prompt agent, byte-for-byte.
+ * subprocess in a chosen project folder. `Remote` (increment 3) drives a
+ * spec-compliant **A2A** server the user points OpenFlow at (their VPS agent, a
+ * hosted flow, any endpoint) over the A2A JSON-RPC binding. Defaults to
+ * `Prompt` so every agent stored before this field existed stays a prompt
+ * agent, byte-for-byte.
  */
-export type AgentKind = "prompt" | "cli"
+export type AgentKind = "prompt" | "cli" | "remote"
 /**
  * What an agent does with its LLM response. `Inject` pastes it at the cursor
  * exactly like a normal dictation; `Clipboard` only copies it (no paste, no

--- a/src/components/settings/agents/AgentCard.tsx
+++ b/src/components/settings/agents/AgentCard.tsx
@@ -20,6 +20,7 @@ import { AgentApiKeyField } from "./AgentApiKeyField";
 import { AgentTestPanel } from "./AgentTestPanel";
 import { AgentInlineToggle } from "./AgentInlineToggle";
 import { CliAgentCard } from "./CliAgentCard";
+import { RemoteAgentCard } from "./RemoteAgentCard";
 
 interface AgentCardProps {
   agent: AgentDefinition;
@@ -37,6 +38,14 @@ export const AgentCard: React.FC<AgentCardProps> = ({ agent, providers }) => {
   // increment-1 agents.
   if (agent.kind === "cli") {
     return <CliAgentCard agent={agent} />;
+  }
+
+  // Remote (A2A) agents (increment 3) render their own card — the prompt-agent
+  // fields below don't apply. Like `cli`, `kind` defaults to "prompt" for every
+  // agent stored before this discriminator existed, so this never affects
+  // increment-1 agents.
+  if (agent.kind === "remote") {
+    return <RemoteAgentCard agent={agent} />;
   }
 
   const [pending, setPending] = useState<Record<string, boolean>>({});

--- a/src/components/settings/agents/AgentsSettings.tsx
+++ b/src/components/settings/agents/AgentsSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { Bot, Plus, Terminal } from "lucide-react";
+import { Bot, Plus, RadioTower, Terminal } from "lucide-react";
 import type { AgentCliType, AgentDefinition } from "@/bindings";
 import { commands } from "@/bindings";
 import { useSettings } from "../../../hooks/useSettings";
@@ -134,6 +134,38 @@ export const AgentsSettings: React.FC = () => {
     }
   };
 
+  const handleAddRemote = async () => {
+    setCreatingKey("remote");
+    try {
+      const name = t("settings.agents.addAgent.remoteAgent");
+      const existingIds = new Set(agents.map((agent) => agent.id));
+      const id = uniqueAgentId(slugify(name), existingIds);
+
+      const result = await commands.createAgent({
+        id,
+        name,
+        binding_id: `agent:${id}`,
+        provider_id: "",
+        kind: "remote",
+        remote_url: "",
+        output_sinks: ["panel"],
+        enabled: true,
+      });
+
+      if (result.status === "error") {
+        toast.error(
+          t("settings.agents.addAgent.error", { error: result.error }),
+        );
+        return;
+      }
+
+      await refreshSettings();
+      toast.success(t("settings.agents.addAgent.created", { name }));
+    } finally {
+      setCreatingKey(null);
+    }
+  };
+
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title={t("settings.agents.title")}>
@@ -194,6 +226,26 @@ export const AgentsSettings: React.FC = () => {
               >
                 <Terminal className="h-4 w-4" />
                 {t("settings.agents.addAgent.cliAgent")}
+              </Button>
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs font-medium text-mid-gray uppercase tracking-wide mb-2">
+              {t("settings.agents.addAgent.remoteSectionTitle")}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={() => void handleAddRemote()}
+                disabled={creatingKey !== null}
+                className="inline-flex items-center gap-1.5"
+                title={t("settings.agents.addAgent.remoteDescription")}
+              >
+                <RadioTower className="h-4 w-4" />
+                {t("settings.agents.addAgent.remoteAgent")}
               </Button>
             </div>
           </div>

--- a/src/components/settings/agents/RemoteAgentCard.tsx
+++ b/src/components/settings/agents/RemoteAgentCard.tsx
@@ -1,0 +1,408 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { RadioTower, Trash2, Zap } from "lucide-react";
+import type {
+  AgentCardSummary,
+  AgentDefinition,
+  AgentOutputSink,
+} from "@/bindings";
+import { commands } from "@/bindings";
+import { useSettings } from "../../../hooks/useSettings";
+import { Input } from "../../ui/Input";
+import { Button } from "../../ui/Button";
+import { Dialog } from "../../ui/Dialog";
+import { Alert } from "../../ui/Alert";
+import { SettingContainer } from "../../ui/SettingContainer";
+import { ShortcutInput } from "../ShortcutInput";
+import { AgentApiKeyField } from "./AgentApiKeyField";
+import { AgentInlineToggle } from "./AgentInlineToggle";
+
+interface RemoteAgentCardProps {
+  agent: AgentDefinition;
+}
+
+const OUTPUT_SINKS: AgentOutputSink[] = ["panel", "notify", "file"];
+
+/**
+ * Remote-agent card (Flow OS increment 3): configures a spec-compliant **A2A**
+ * server instead of a local CLI subprocess or a persona-LLM transform. Mirrors
+ * `CliAgentCard`'s layout/patterns (header row, `ShortcutInput`,
+ * `SettingContainer` rows, optimistic drafts committed via `commands.updateAgent`
+ * + `refreshSettings`, Alert-based status). The bearer token reuses
+ * `AgentApiKeyField` against keyring scope "agent"/agent id.
+ */
+export const RemoteAgentCard: React.FC<RemoteAgentCardProps> = ({ agent }) => {
+  const { t } = useTranslation();
+  const { refreshSettings } = useSettings();
+
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+  const [nameDraft, setNameDraft] = useState(agent.name);
+  const [urlDraft, setUrlDraft] = useState(agent.remote_url ?? "");
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const [card, setCard] = useState<AgentCardSummary | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => setNameDraft(agent.name), [agent.name]);
+  useEffect(() => setUrlDraft(agent.remote_url ?? ""), [agent.remote_url]);
+
+  const isPending = (field: string) => pending[field] ?? false;
+
+  const persist = async (
+    patch: Partial<AgentDefinition>,
+    field: string,
+  ): Promise<boolean> => {
+    setPending((prev) => ({ ...prev, [field]: true }));
+    try {
+      const result = await commands.updateAgent({ ...agent, ...patch });
+      if (result.status === "error") {
+        toast.error(
+          t("settings.agents.card.update.error", { error: result.error }),
+        );
+        return false;
+      }
+      await refreshSettings();
+      return true;
+    } finally {
+      setPending((prev) => ({ ...prev, [field]: false }));
+    }
+  };
+
+  const commitName = () => {
+    const trimmed = nameDraft.trim();
+    if (!trimmed) {
+      setNameDraft(agent.name);
+      return;
+    }
+    if (trimmed === agent.name) return;
+    void persist({ name: trimmed }, "name");
+  };
+
+  const commitUrl = () => {
+    const trimmed = urlDraft.trim();
+    if (trimmed === (agent.remote_url ?? "")) return;
+    // Changing the URL invalidates the cached endpoint/card metadata.
+    void persist(
+      {
+        remote_url: trimmed,
+        remote_endpoint: "",
+        remote_card_name: "",
+        remote_card_version: "",
+        remote_streaming: false,
+      },
+      "remote_url",
+    );
+    setCard(null);
+    setFetchError(null);
+  };
+
+  const handleFetchCard = async () => {
+    // Persist any pending URL edit first so the backend fetches the right one.
+    const trimmed = urlDraft.trim();
+    if (trimmed !== (agent.remote_url ?? "")) {
+      const ok = await persist(
+        {
+          remote_url: trimmed,
+          remote_endpoint: "",
+          remote_card_name: "",
+          remote_card_version: "",
+          remote_streaming: false,
+        },
+        "remote_url",
+      );
+      if (!ok) return;
+    }
+    setPending((prev) => ({ ...prev, fetch: true }));
+    setFetchError(null);
+    try {
+      const result = await commands.fetchRemoteAgentCard(agent.id);
+      if (result.status === "error") {
+        setCard(null);
+        setFetchError(result.error);
+        return;
+      }
+      setCard(result.data);
+      await refreshSettings();
+    } catch (err) {
+      setCard(null);
+      setFetchError(String(err));
+    } finally {
+      setPending((prev) => ({ ...prev, fetch: false }));
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      const result = await commands.deleteAgent(agent.id);
+      if (result.status === "error") {
+        toast.error(
+          t("settings.agents.card.delete.error", { error: result.error }),
+        );
+        return;
+      }
+      await refreshSettings();
+      toast.success(
+        t("settings.agents.card.delete.success", { name: agent.name }),
+      );
+      setConfirmingDelete(false);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const toggleOutputSink = (sink: AgentOutputSink) => {
+    const current = agent.output_sinks ?? ["panel"];
+    const has = current.includes(sink);
+    let next: AgentOutputSink[];
+    if (has) {
+      // An agent must always land its output somewhere (defaults to Panel).
+      if (current.length <= 1) return;
+      next = current.filter((s) => s !== sink);
+    } else {
+      next = [...current, sink];
+    }
+    void persist({ output_sinks: next }, "output_sinks");
+  };
+
+  const activeOutputSinks = agent.output_sinks ?? ["panel"];
+
+  // Prefer the just-fetched summary; fall back to what's cached on the agent so
+  // a previously-fetched card still shows after a reload.
+  const cardName = card?.name ?? agent.remote_card_name ?? "";
+  const cardVersion = card?.version ?? agent.remote_card_version ?? "";
+  const cardStreaming = card?.streaming ?? agent.remote_streaming ?? false;
+  const cardEndpoint = card?.endpoint ?? agent.remote_endpoint ?? "";
+  const hasCard = cardName.length > 0 || cardEndpoint.length > 0;
+
+  return (
+    <div className="bg-background border border-mid-gray/20 rounded-lg divide-y divide-mid-gray/20">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Input
+          type="text"
+          variant="compact"
+          value={nameDraft}
+          disabled={isPending("name")}
+          onChange={(event) => setNameDraft(event.target.value)}
+          onBlur={commitName}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              event.currentTarget.blur();
+            }
+          }}
+          placeholder={t("settings.agents.card.name.placeholder")}
+          className="flex-1 min-w-0 font-semibold"
+          aria-label={t("settings.agents.card.name.label")}
+        />
+        <AgentInlineToggle
+          checked={agent.enabled ?? true}
+          disabled={isPending("enabled")}
+          onChange={(checked) => void persist({ enabled: checked }, "enabled")}
+          label={t("settings.agents.card.enabled.label")}
+        />
+        <Button
+          type="button"
+          variant="danger-ghost"
+          size="sm"
+          onClick={() => setConfirmingDelete(true)}
+          aria-label={t("settings.agents.card.delete.button")}
+          title={t("settings.agents.card.delete.button")}
+          className="shrink-0"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <ShortcutInput shortcutId={agent.binding_id} grouped />
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.url.label")}
+        description={t("settings.agents.card.remote.url.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="stacked"
+      >
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            variant="compact"
+            value={urlDraft}
+            disabled={isPending("remote_url")}
+            onChange={(event) => setUrlDraft(event.target.value)}
+            onBlur={commitUrl}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                event.currentTarget.blur();
+              }
+            }}
+            placeholder={t("settings.agents.card.remote.url.placeholder")}
+            className="flex-1 min-w-0"
+            aria-label={t("settings.agents.card.remote.url.label")}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            size="md"
+            onClick={() => void handleFetchCard()}
+            disabled={isPending("fetch") || !urlDraft.trim()}
+            className="inline-flex shrink-0 items-center gap-1.5"
+          >
+            <RadioTower className="h-4 w-4" />
+            {isPending("fetch")
+              ? t("settings.agents.card.remote.fetch.fetching")
+              : t("settings.agents.card.remote.fetch.button")}
+          </Button>
+        </div>
+      </SettingContainer>
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.token.label")}
+        description={t("settings.agents.card.remote.token.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="horizontal"
+      >
+        <AgentApiKeyField agentId={agent.id} />
+      </SettingContainer>
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.fetch.label")}
+        description={t("settings.agents.card.remote.fetch.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="stacked"
+      >
+        <div className="space-y-2">
+          {fetchError && (
+            <Alert variant="error" contained>
+              {t("settings.agents.card.remote.fetch.error", {
+                error: fetchError,
+              })}
+            </Alert>
+          )}
+          {!fetchError && hasCard && (
+            <Alert variant="success" contained>
+              <div className="space-y-1.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-semibold">{cardName}</span>
+                  {cardVersion && (
+                    <span className="text-xs text-mid-gray">
+                      {t("settings.agents.card.remote.fetch.version", {
+                        version: cardVersion,
+                      })}
+                    </span>
+                  )}
+                  {cardStreaming && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-background-ui/60 px-2 py-0.5 text-xs">
+                      <Zap className="h-3 w-3" />
+                      {t("settings.agents.card.remote.fetch.streaming")}
+                    </span>
+                  )}
+                </div>
+                {cardEndpoint && (
+                  <p
+                    className="truncate text-xs text-mid-gray"
+                    title={cardEndpoint}
+                  >
+                    {t("settings.agents.card.remote.fetch.endpoint", {
+                      endpoint: cardEndpoint,
+                    })}
+                  </p>
+                )}
+                {card?.auth_schemes && card.auth_schemes.length > 0 && (
+                  <p className="text-xs text-mid-gray">
+                    {t("settings.agents.card.remote.fetch.auth", {
+                      schemes: card.auth_schemes.join(", "),
+                    })}
+                  </p>
+                )}
+                {card?.skills && card.skills.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 pt-0.5">
+                    {card.skills.map((skill) => (
+                      <span
+                        key={skill.id}
+                        className="rounded-full bg-background-ui/60 px-2 py-0.5 text-xs"
+                        title={skill.id}
+                      >
+                        {skill.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </Alert>
+          )}
+          {!fetchError && !hasCard && (
+            <p className="text-sm text-mid-gray">
+              {t("settings.agents.card.remote.fetch.notFetched")}
+            </p>
+          )}
+        </div>
+      </SettingContainer>
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.outputSinks.label")}
+        description={t("settings.agents.card.remote.outputSinks.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="horizontal"
+      >
+        <div className="flex items-center gap-3">
+          {OUTPUT_SINKS.map((sink) => (
+            <label
+              key={sink}
+              className="flex items-center gap-1.5 text-sm cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={activeOutputSinks.includes(sink)}
+                disabled={isPending("output_sinks")}
+                onChange={() => toggleOutputSink(sink)}
+                className="h-4 w-4 rounded border-mid-gray/80 accent-background-ui"
+              />
+              {t(`settings.agents.card.remote.outputSinks.${sink}`)}
+            </label>
+          ))}
+        </div>
+      </SettingContainer>
+
+      <Dialog
+        open={confirmingDelete}
+        onOpenChange={setConfirmingDelete}
+        title={t("settings.agents.card.delete.confirmTitle", {
+          name: agent.name,
+        })}
+        description={t("settings.agents.card.delete.confirmDescription")}
+        closeLabel={t("settings.agents.card.delete.cancel")}
+        footer={
+          <>
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={() => setConfirmingDelete(false)}
+              disabled={isDeleting}
+            >
+              {t("settings.agents.card.delete.cancel")}
+            </Button>
+            <Button
+              type="button"
+              variant="danger"
+              size="md"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {t("settings.agents.card.delete.confirm")}
+            </Button>
+          </>
+        }
+      >
+        <></>
+      </Dialog>
+    </div>
+  );
+};

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -692,7 +692,10 @@
         "promptSectionTitle": "Prompt agents",
         "cliSectionTitle": "CLI agents",
         "cliAgent": "CLI agent",
-        "cliDescription": "Drive a real coding-agent CLI (Claude Code, Codex, …) as a subprocess in a project folder."
+        "cliDescription": "Drive a real coding-agent CLI (Claude Code, Codex, …) as a subprocess in a project folder.",
+        "remoteSectionTitle": "Remote agents",
+        "remoteAgent": "Remote agent (A2A)",
+        "remoteDescription": "Point a hotkey at any spec-compliant A2A server — your VPS agent, a hosted flow, any endpoint."
       },
       "card": {
         "name": {
@@ -803,6 +806,37 @@
             "placeholder": "e.g. -p --output-format stream-json --verbose",
             "show": "Show advanced",
             "hide": "Hide advanced"
+          },
+          "outputSinks": {
+            "label": "Output",
+            "description": "Where this run's output goes when it finishes.",
+            "panel": "Panel",
+            "notify": "Notify",
+            "file": "File"
+          }
+        },
+        "remote": {
+          "url": {
+            "label": "Agent URL",
+            "description": "The base URL of the A2A agent. OpenFlow reads its card from /.well-known/agent-card.json (or paste a full card URL).",
+            "placeholder": "e.g. https://agent.example.com"
+          },
+          "token": {
+            "label": "Token",
+            "description": "Optional bearer token sent with every request. Stored in your OS keychain, never in settings."
+          },
+          "fetch": {
+            "label": "Agent card",
+            "description": "Fetch the card to resolve the agent's JSON-RPC endpoint and capabilities.",
+            "button": "Fetch card",
+            "fetching": "Fetching…",
+            "error": "Couldn't fetch the card: {{error}}",
+            "notFetched": "No card fetched yet. Enter the URL above and fetch the card.",
+            "streaming": "Streaming",
+            "endpoint": "Endpoint: {{endpoint}}",
+            "version": "v{{version}}",
+            "skills": "Skills",
+            "auth": "Auth: {{schemes}}"
           },
           "outputSinks": {
             "label": "Output",


### PR DESCRIPTION
## What this is

**Rebase of #43 (`feat/remote-agents`) onto the rebased service-connect branch.**
Opened as a **new branch for side-by-side comparison** with #43 — #43 is left untouched.

**Stacked PR:** base is `feat/service-connect-rebased` (the rebased #42). Review/merge
that one first. Both of remote-agents' commits (A2A driver + SSE UTF-8 fix) cherry-picked
onto current `main`'s agent code (post Kimi #50 / OpenClaw+Hermes #51) **with zero
conflicts** — the compiler + full suite confirm the merge is semantically valid.

## Human Written Description

<!-- TODO(@avijeett007): 2–3 sentences in your own words — the problem/idea and why it
matters. This section must be your own thinking, not AI text (repo rule). -->

## What it adds (unchanged from #43, additive & non-breaking)

Remote agents over **A2A** (JSON-RPC + SSE) as a third `AgentKind::Remote`, a sibling
driver behind the existing `AgentRunManager::start` seam (run panel + hotkey dispatch
reused unchanged):
- `a2a.rs` (hand-rolled reqwest/serde A2A client: agent-card parse v0.3+v1.0, JSON-RPC
  envelope, SSE parser with cross-chunk UTF-8 reassembly, task poll/cancel).
- `commands/remote_agents.rs`: `fetch_remote_agent_card` + `test_remote_agent`.
- `RemoteAgentCard.tsx` UI; `AgentKind::Remote` + five `#[serde(default)]` fields on
  `AgentDefinition`; bearer token in the OS keyring (scope `"agent"`).

This is the "point OpenFlow at an A2A agent running on your VPS" piece. See
DESIGN-remote-agents.md (§3/§5) for the planned follow-on transports (OpenAI-compat REST
for Hermes, ACP for Kimi) — not in this PR.

## Related

Comparison against original: #43. Base PR: the rebased #42 (`feat/service-connect-rebased`).
Design: DESIGN-remote-agents.md.

## Testing

Verified locally on Intel macOS 14.5, stacked on the rebased service branch on current
`main` (`86cab3d`):
- `cargo test --lib`: **374 passed / 0 failed** (328 base + 46 new a2a/remote tests:
  card parse both shapes, endpoint selection, JSON-RPC envelope, SSE split-across-chunks
  + CRLF, UTF-8 reassembly, dispatch, state mapping, poll-cap, cancel-mid-poll).
- `cargo check --lib` exit 0; `tsc --noEmit` exit 0; `eslint src` 0 errors.
- `bindings.ts` regenerated from Rust → **zero drift**.

**Non-breaking proof:** `AgentKind` defaults to `Prompt`; every new field `#[serde(default)]`;
zero remote agents configured ⇒ settings + every code path byte-for-byte unchanged
(legacy-store round-trip tests pass).

## AI Assistance

- [x] AI was used (please describe below)

**If AI was used:**
- Tools used: Claude Code (rebase/cherry-pick onto current main, conflict analysis, verification).
- How extensively: AI rebased the original #43 payload onto the rebased #42 and current
  main's agent code, regenerated bindings, and ran the build/test verification above. The
  underlying feature code is the original #43 payload. Human review + Human-Written
  Description pending the maintainer.
