### PR TITLE
feat(agents): remote agents over A2A (#58 recovered)

### DIFF
--- a/src-tauri/src/a2a.rs
+++ b/src-tauri/src/a2a.rs
@@ -580,6 +580,63 @@ impl SseParser {
 }
 
 // ---------------------------------------------------------------------------
+// Incremental UTF-8 decoder (network chunk boundaries do NOT respect UTF-8
+// char boundaries; decoding each chunk independently would turn a multi-byte
+// character split across two chunks into replacement chars)
+// ---------------------------------------------------------------------------
+
+/// Decodes a byte stream to UTF-8 incrementally, holding back an INCOMPLETE
+/// trailing multi-byte sequence until its continuation bytes arrive in a later
+/// chunk. A genuinely invalid sequence is emitted as one replacement char (and
+/// skipped) so a hostile/broken stream can't stall the decoder.
+#[derive(Default)]
+pub struct Utf8Buffer {
+    tail: Vec<u8>,
+}
+
+impl Utf8Buffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push raw bytes; return the longest now-decodable UTF-8 text, retaining
+    /// any incomplete trailing sequence for the next call.
+    pub fn push(&mut self, bytes: &[u8]) -> String {
+        self.tail.extend_from_slice(bytes);
+        let mut out = String::new();
+        loop {
+            match std::str::from_utf8(&self.tail) {
+                Ok(s) => {
+                    out.push_str(s);
+                    self.tail.clear();
+                    break;
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    if valid > 0 {
+                        // SAFETY-of-logic: bytes[..valid] is valid UTF-8 by definition.
+                        out.push_str(std::str::from_utf8(&self.tail[..valid]).unwrap_or(""));
+                    }
+                    match e.error_len() {
+                        // Incomplete (could still become valid) — keep the tail.
+                        None => {
+                            self.tail.drain(..valid);
+                            break;
+                        }
+                        // Genuinely invalid — emit one replacement, skip it, continue.
+                        Some(bad) => {
+                            out.push('\u{FFFD}');
+                            self.tail.drain(..valid + bad);
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Transport (mirror of ServiceTransport: HTTP behind a trait so the driver is
 // unit-testable against a mock with no network)
 // ---------------------------------------------------------------------------
@@ -738,11 +795,13 @@ impl A2aTransport for HttpA2aTransport {
 
         struct StreamState<S> {
             inner: S,
+            decoder: Utf8Buffer,
             parser: SseParser,
             queue: std::collections::VecDeque<String>,
         }
         let state = StreamState {
             inner: resp.bytes_stream(),
+            decoder: Utf8Buffer::new(),
             parser: SseParser::new(),
             queue: std::collections::VecDeque::new(),
         };
@@ -758,7 +817,9 @@ impl A2aTransport for HttpA2aTransport {
                 }
                 match st.inner.next().await {
                     Some(Ok(bytes)) => {
-                        let text = String::from_utf8_lossy(&bytes);
+                        // Decode incrementally: a multi-byte char split across a
+                        // network chunk boundary must not be mangled into U+FFFD.
+                        let text = st.decoder.push(&bytes);
                         for data in st.parser.feed(&text) {
                             st.queue.push_back(data);
                         }
@@ -1458,6 +1519,53 @@ mod tests {
         let out = p.feed("data: not json\n\n");
         assert_eq!(out, vec!["not json".to_string()]);
         assert!(serde_json::from_str::<Value>(&out[0]).is_err());
+    }
+
+    // ---- incremental UTF-8 decoder -----------------------------------------
+
+    #[test]
+    fn utf8_buffer_passes_ascii_through() {
+        let mut b = Utf8Buffer::new();
+        assert_eq!(b.push(b"hello"), "hello");
+        assert_eq!(b.push(b" world"), " world");
+    }
+
+    #[test]
+    fn utf8_buffer_reassembles_two_byte_char_split_across_chunks() {
+        // "é" = 0xC3 0xA9. Split between the two bytes at a chunk boundary.
+        let mut b = Utf8Buffer::new();
+        assert_eq!(b.push(&[0xC3]), ""); // incomplete — held back, NOT mangled
+        assert_eq!(b.push(&[0xA9]), "é");
+    }
+
+    #[test]
+    fn utf8_buffer_reassembles_four_byte_emoji_split_across_chunks() {
+        // "😀" = F0 9F 98 80. Feed it one byte at a time.
+        let bytes = "😀".as_bytes().to_vec();
+        let mut b = Utf8Buffer::new();
+        let mut out = String::new();
+        for byte in bytes {
+            out.push_str(&b.push(&[byte]));
+        }
+        assert_eq!(out, "😀");
+    }
+
+    #[test]
+    fn utf8_buffer_mixed_ascii_and_split_multibyte() {
+        // "aé" split so the ASCII 'a' plus the first byte of 'é' arrive together.
+        let mut b = Utf8Buffer::new();
+        assert_eq!(b.push(&[b'a', 0xC3]), "a");
+        assert_eq!(b.push(&[0xA9, b'b']), "éb");
+    }
+
+    #[test]
+    fn utf8_buffer_emits_replacement_for_genuinely_invalid_bytes() {
+        // A lone continuation byte 0x80 is invalid, not incomplete — must not
+        // stall the decoder; it yields one replacement and continues.
+        let mut b = Utf8Buffer::new();
+        let out = b.push(&[0x80, b'x']);
+        assert!(out.contains('x'), "got: {out:?}");
+        assert!(out.contains('\u{FFFD}'), "got: {out:?}");
     }
 
     #[test]

--- a/src-tauri/src/a2a.rs
+++ b/src-tauri/src/a2a.rs
@@ -1,0 +1,1854 @@
+//! Flow OS increment 3 — a thin, hand-rolled **A2A (Agent-to-Agent)** client for
+//! the `RemoteDriver`. A remote agent is a spec-compliant A2A server the user
+//! points OpenFlow at; it joins the same agent registry, hotkeys, voice routing
+//! and run panel as CLI/prompt agents (see `DESIGN-remote-agents.md`).
+//!
+//! Scope is deliberately narrow: the A2A **JSON-RPC binding** only (no gRPC /
+//! HTTP+JSON), built on `reqwest` + `serde_json` with NO `a2a-*` crates (pre-1.0
+//! churn + gRPC weight). We accept agent cards advertising `protocolVersion`
+//! 0.3.x AND 1.0.x — the two shapes are wire-identical for the four methods we
+//! use (`message/send`, `tasks/get`, `tasks/cancel`, `message/stream`).
+//!
+//! Everything here is pure/testable except the production `HttpA2aTransport`:
+//! card parsing, endpoint selection, JSON-RPC envelope handling, the SSE frame
+//! parser and the driver protocol loop all run against a mock transport with no
+//! network (see the tests at the bottom + the driver tests in `agent_run.rs`).
+
+use std::collections::HashSet;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use futures_util::{Stream, StreamExt};
+use serde::Serialize;
+use serde_json::{json, Value};
+use specta::Type;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
+
+// ---------------------------------------------------------------------------
+// Method strings (A2A JSON-RPC binding)
+// ---------------------------------------------------------------------------
+
+pub const METHOD_MESSAGE_SEND: &str = "message/send";
+pub const METHOD_MESSAGE_STREAM: &str = "message/stream";
+pub const METHOD_TASKS_GET: &str = "tasks/get";
+pub const METHOD_TASKS_CANCEL: &str = "tasks/cancel";
+
+// ---------------------------------------------------------------------------
+// Request ids (no `uuid` dependency — a unique-per-request id is all JSON-RPC
+// and A2A `messageId` need). Non-cryptographic; combines a process seed, the
+// clock and a monotonic counter, formatted UUID-v4-shaped for server-friendliness.
+// ---------------------------------------------------------------------------
+
+static ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A unique request/message id, formatted like a v4 UUID.
+pub fn new_request_id() -> String {
+    let counter = ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    // Two 64-bit lanes mixed with splitmix64 so the hex is well-distributed.
+    let a = splitmix64(nanos ^ (counter.wrapping_mul(0x9E37_79B9_7F4A_7C15)));
+    let b = splitmix64(counter ^ (nanos.rotate_left(32)));
+    let time_low = (a >> 32) as u32;
+    let time_mid = (a >> 16) as u16;
+    let time_hi = ((a as u16) & 0x0FFF) | 0x4000; // version 4
+    let clock = ((b >> 48) as u16 & 0x3FFF) | 0x8000; // variant 10xx
+    let node = b & 0xFFFF_FFFF_FFFF;
+    format!("{time_low:08x}-{time_mid:04x}-{time_hi:04x}-{clock:04x}-{node:012x}")
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = x;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+// ---------------------------------------------------------------------------
+// Agent card — tolerant parse of BOTH the v0.3 and v1.0 shapes
+// ---------------------------------------------------------------------------
+
+/// A normalized transport interface extracted from a card.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interface {
+    pub url: String,
+    pub transport: String,
+}
+
+/// The bits of an agent card OpenFlow cares about, normalized across card
+/// versions. Unknown fields are ignored (tolerant parse).
+#[derive(Debug, Clone)]
+pub struct AgentCard {
+    pub name: String,
+    pub version: String,
+    pub streaming: bool,
+    /// Transport interfaces in preference order (top-level/preferred first).
+    pub interfaces: Vec<Interface>,
+    pub auth_schemes: Vec<String>,
+    pub skills: Vec<AgentCardSkill>,
+}
+
+/// UI-facing summary returned by `fetch_remote_agent_card` / persisted on the agent.
+#[derive(Debug, Clone, Serialize, Type)]
+pub struct AgentCardSummary {
+    pub name: String,
+    pub version: String,
+    pub streaming: bool,
+    /// The resolved JSON-RPC endpoint (empty only if selection somehow failed —
+    /// callers error out before building a summary in that case).
+    pub endpoint: String,
+    pub auth_schemes: Vec<String>,
+    pub skills: Vec<AgentCardSkill>,
+}
+
+#[derive(Debug, Clone, Serialize, Type, PartialEq, Eq)]
+pub struct AgentCardSkill {
+    pub id: String,
+    pub name: String,
+}
+
+/// Derive the well-known agent-card URL from a user-entered base URL. A URL that
+/// already points at a card (`…/agent-card.json` or an `…/.well-known/…` path)
+/// is accepted verbatim; otherwise we append the well-known path to the origin+path.
+pub fn well_known_card_url(entered: &str) -> String {
+    let trimmed = entered.trim();
+    if trimmed.ends_with("agent-card.json") || trimmed.contains("/.well-known/") {
+        return trimmed.to_string();
+    }
+    let base = trimmed.trim_end_matches('/');
+    format!("{base}/.well-known/agent-card.json")
+}
+
+/// Parse an agent card JSON value into the normalized [`AgentCard`]. Accepts the
+/// v0.3 shape (`url` + `preferredTransport` + `additionalInterfaces`) and the
+/// v1.0 shape (`supportedInterfaces`), merging both when present.
+pub fn parse_agent_card(v: &Value) -> Result<AgentCard, String> {
+    if !v.is_object() {
+        return Err("The agent card was not a JSON object.".to_string());
+    }
+    let name = v
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let version = v
+        .get("version")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let streaming = v
+        .get("capabilities")
+        .and_then(|c| c.get("streaming"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut interfaces: Vec<Interface> = Vec::new();
+
+    // v0.3 top-level url + preferredTransport. Per the A2A spec, when
+    // `preferredTransport` is omitted the transport at `url` is JSONRPC.
+    if let Some(url) = v.get("url").and_then(Value::as_str) {
+        if !url.is_empty() {
+            let transport = v
+                .get("preferredTransport")
+                .and_then(Value::as_str)
+                .unwrap_or("JSONRPC")
+                .to_string();
+            interfaces.push(Interface {
+                url: url.to_string(),
+                transport,
+            });
+        }
+    }
+    // v0.3 additionalInterfaces: [{url, transport}].
+    if let Some(arr) = v.get("additionalInterfaces").and_then(Value::as_array) {
+        for it in arr {
+            if let Some(url) = it.get("url").and_then(Value::as_str) {
+                let transport = it
+                    .get("transport")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                interfaces.push(Interface {
+                    url: url.to_string(),
+                    transport,
+                });
+            }
+        }
+    }
+    // v1.0 supportedInterfaces: [{url, protocolBinding|transport, protocolVersion}].
+    if let Some(arr) = v.get("supportedInterfaces").and_then(Value::as_array) {
+        for it in arr {
+            if let Some(url) = it.get("url").and_then(Value::as_str) {
+                let transport = it
+                    .get("protocolBinding")
+                    .or_else(|| it.get("transport"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                interfaces.push(Interface {
+                    url: url.to_string(),
+                    transport,
+                });
+            }
+        }
+    }
+
+    let auth_schemes = parse_auth_schemes(v);
+    let skills = parse_skills(v);
+
+    Ok(AgentCard {
+        name,
+        version,
+        streaming,
+        interfaces,
+        auth_schemes,
+        skills,
+    })
+}
+
+fn parse_auth_schemes(v: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(obj) = v.get("securitySchemes").and_then(Value::as_object) {
+        for scheme in obj.values() {
+            if let Some(t) = scheme.get("type").and_then(Value::as_str) {
+                if !out.iter().any(|s| s == t) {
+                    out.push(t.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn parse_skills(v: &Value) -> Vec<AgentCardSkill> {
+    v.get("skills")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| {
+                    let id = s.get("id").and_then(Value::as_str)?.to_string();
+                    let name = s
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or(&id)
+                        .to_string();
+                    Some(AgentCardSkill { id, name })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Normalize a transport/binding label to a comparable token (lowercase, only
+/// alphanumerics) so `JSONRPC`, `jsonrpc`, `JSON-RPC` all compare equal.
+fn transport_token(t: &str) -> String {
+    t.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+fn is_jsonrpc(t: &str) -> bool {
+    transport_token(t) == "jsonrpc"
+}
+
+impl AgentCard {
+    /// Select the JSON-RPC endpoint URL: the first interface (in preference
+    /// order) whose transport is JSON-RPC. Errors clearly when none exists.
+    pub fn select_jsonrpc_endpoint(&self) -> Result<String, String> {
+        self.interfaces
+            .iter()
+            .find(|i| is_jsonrpc(&i.transport) && !i.url.is_empty())
+            .map(|i| i.url.clone())
+            .ok_or_else(|| {
+                "This agent doesn't offer a JSON-RPC interface. OpenFlow only \
+                 speaks the A2A JSON-RPC binding."
+                    .to_string()
+            })
+    }
+
+    pub fn summary(&self, endpoint: String) -> AgentCardSummary {
+        AgentCardSummary {
+            name: self.name.clone(),
+            version: self.version.clone(),
+            streaming: self.streaming,
+            endpoint,
+            auth_schemes: self.auth_schemes.clone(),
+            skills: self.skills.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC envelope
+// ---------------------------------------------------------------------------
+
+/// A JSON-RPC 2.0 request body.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: &'static str,
+    pub id: String,
+    pub method: String,
+    pub params: Value,
+}
+
+impl JsonRpcRequest {
+    pub fn new(method: &str, params: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id: new_request_id(),
+            method: method.to_string(),
+            params,
+        }
+    }
+}
+
+/// Parse a JSON-RPC response envelope: **error before result** (a well-formed
+/// error response can technically also carry a null `result`). Returns the
+/// `result` value on success, or a formatted `code: message` error string.
+pub fn parse_jsonrpc_envelope(v: &Value) -> Result<Value, String> {
+    if let Some(err) = v.get("error") {
+        if !err.is_null() {
+            let code = err.get("code").and_then(Value::as_i64).unwrap_or(0);
+            let message = err
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown error");
+            return Err(format!("{code}: {message}"));
+        }
+    }
+    match v.get("result") {
+        Some(result) if !result.is_null() => Ok(result.clone()),
+        _ => Err("the response had neither a result nor an error".to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Message / Part / Task text extraction
+// ---------------------------------------------------------------------------
+
+/// Build the `message/send`|`message/stream` params for an instruction.
+pub fn build_send_params(instruction: &str) -> Value {
+    json!({
+        "message": {
+            "role": "user",
+            "parts": [{ "kind": "text", "text": instruction }],
+            "messageId": new_request_id(),
+        }
+    })
+}
+
+/// Turn one A2A `Part` into a displayable line. Text parts yield their text;
+/// non-text parts are summarized (`[file: name]` / `[data]`) rather than dumped.
+pub fn part_to_text(part: &Value) -> Option<String> {
+    let kind = part
+        .get("kind")
+        .or_else(|| part.get("type"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    match kind {
+        "file" => {
+            let name = part
+                .get("file")
+                .and_then(|f| f.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("file");
+            Some(format!("[file: {name}]"))
+        }
+        "data" => Some("[data]".to_string()),
+        // "text" or an unlabeled part that nonetheless carries text.
+        _ => part
+            .get("text")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string()),
+    }
+}
+
+/// Collect the displayable text chunks from a `parts` array.
+fn parts_text(parts: Option<&Value>) -> Vec<String> {
+    parts
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().filter_map(part_to_text).collect())
+        .unwrap_or_default()
+}
+
+/// Extract text chunks from a `message` result (direct reply).
+pub fn message_text(msg: &Value) -> Vec<String> {
+    parts_text(msg.get("parts"))
+}
+
+/// Extract the NEW-this-snapshot text chunks from a `task`: its status message
+/// parts plus every artifact's parts. Callers dedupe across polls.
+pub fn task_text_chunks(task: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(status) = task.get("status") {
+        out.extend(parts_text(
+            status.get("message").and_then(|m| m.get("parts")),
+        ));
+    }
+    if let Some(arts) = task.get("artifacts").and_then(Value::as_array) {
+        for art in arts {
+            out.extend(parts_text(art.get("parts")));
+        }
+    }
+    out
+}
+
+/// The `state` string of a task/status object, if present.
+pub fn task_state(task: &Value) -> Option<String> {
+    task.get("status")
+        .and_then(|s| s.get("state"))
+        .or_else(|| task.get("state"))
+        .and_then(Value::as_str)
+        .map(|s| s.to_string())
+}
+
+/// The human message attached to a task/status, if any (used in Failed text).
+pub fn task_status_message(task: &Value) -> Option<String> {
+    let parts = task
+        .get("status")
+        .and_then(|s| s.get("message"))
+        .and_then(|m| m.get("parts"));
+    let text = parts_text(parts).join(" ");
+    if text.trim().is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// send-result dispatch + task-state classification
+// ---------------------------------------------------------------------------
+
+/// What a `message/send` result represents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendDispatch {
+    /// A direct reply — the concatenated text is final.
+    DirectMessage(Vec<String>),
+    /// A long-running task to track by id (with any text already present).
+    Task {
+        id: String,
+        initial_text: Vec<String>,
+    },
+    /// A task with no id — unusable (server bug); surfaced as a failure.
+    UnusableTask,
+}
+
+/// Dispatch a `message/send` result on its `kind` (`"message"` vs `"task"`),
+/// with a structural fallback for cards that omit `kind`.
+pub fn dispatch_send_result(result: &Value) -> SendDispatch {
+    let kind = result.get("kind").and_then(Value::as_str);
+    let looks_like_task = result.get("status").is_some() || result.get("artifacts").is_some();
+    let is_task = matches!(kind, Some("task")) || (kind.is_none() && looks_like_task);
+    if is_task {
+        match result.get("id").and_then(Value::as_str) {
+            Some(id) if !id.is_empty() => SendDispatch::Task {
+                id: id.to_string(),
+                initial_text: task_text_chunks(result),
+            },
+            _ => SendDispatch::UnusableTask,
+        }
+    } else {
+        SendDispatch::DirectMessage(message_text(result))
+    }
+}
+
+/// Terminal/non-terminal classification of an A2A task state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateClass {
+    /// `submitted` / `working` — keep going.
+    NonTerminal,
+    /// `completed`.
+    Finished,
+    /// `failed` / `rejected` — carries the server message when present.
+    Failed(Option<String>),
+    /// `canceled`.
+    Stopped,
+    /// `input-required` / `auth-required` — multi-turn, unsupported in v1.
+    NeedsInput,
+    /// An unrecognized state string — treated as non-terminal (keep polling).
+    Unknown,
+}
+
+/// Map an A2A task `state` string to its [`StateClass`].
+pub fn classify_state(state: &str, server_message: Option<String>) -> StateClass {
+    match state {
+        "submitted" | "working" => StateClass::NonTerminal,
+        "completed" => StateClass::Finished,
+        "failed" | "rejected" => StateClass::Failed(server_message),
+        "canceled" | "cancelled" => StateClass::Stopped,
+        "input-required" | "auth-required" => StateClass::NeedsInput,
+        _ => StateClass::Unknown,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Poll-append dedupe
+// ---------------------------------------------------------------------------
+
+/// Tracks text chunks already emitted so re-polling a task (whose artifacts/
+/// status message accumulate) doesn't re-print what the user already saw.
+#[derive(Default)]
+pub struct TextDedup {
+    seen: HashSet<String>,
+}
+
+impl TextDedup {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return `Some(text)` the first time a chunk is seen, `None` afterwards.
+    pub fn push(&mut self, text: &str) -> Option<String> {
+        if text.is_empty() {
+            return None;
+        }
+        if self.seen.insert(text.to_string()) {
+            Some(text.to_string())
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SSE frame parser (manual; feed decoded text, get complete event data payloads)
+// ---------------------------------------------------------------------------
+
+/// A minimal Server-Sent-Events parser sufficient for A2A `message/stream`:
+/// handles multi-line `data:` (joined with `\n`), comment lines (`:` prefix),
+/// CRLF line endings, and events split across chunk boundaries. Non-`data`
+/// fields (`event`, `id`, `retry`) are ignored — each A2A frame is a JSON-RPC
+/// envelope carried entirely in `data`.
+#[derive(Default)]
+pub struct SseParser {
+    buf: String,
+    data_lines: Vec<String>,
+}
+
+impl SseParser {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed a decoded text chunk; return the `data` payload of every event that
+    /// completed (was terminated by a blank line) within it.
+    pub fn feed(&mut self, chunk: &str) -> Vec<String> {
+        self.buf.push_str(chunk);
+        let mut out = Vec::new();
+        while let Some(nl) = self.buf.find('\n') {
+            let mut line: String = self.buf.drain(..=nl).collect();
+            line.pop(); // drop the '\n'
+            if line.ends_with('\r') {
+                line.pop();
+            }
+            if line.is_empty() {
+                // Blank line — dispatch the buffered event (if any).
+                if !self.data_lines.is_empty() {
+                    out.push(self.data_lines.join("\n"));
+                    self.data_lines.clear();
+                }
+                continue;
+            }
+            if line.starts_with(':') {
+                continue; // comment
+            }
+            let (field, value) = match line.find(':') {
+                Some(i) => {
+                    let field = line[..i].to_string();
+                    let mut value = line[i + 1..].to_string();
+                    if let Some(stripped) = value.strip_prefix(' ') {
+                        value = stripped.to_string();
+                    }
+                    (field, value)
+                }
+                None => (line.clone(), String::new()),
+            };
+            if field == "data" {
+                self.data_lines.push(value);
+            }
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport (mirror of ServiceTransport: HTTP behind a trait so the driver is
+// unit-testable against a mock with no network)
+// ---------------------------------------------------------------------------
+
+/// A stream of parsed JSON-RPC `result` values (one per SSE frame). Each item is
+/// the frame's `result` object, or an error for a JSON-RPC-error frame / stream
+/// transport error.
+pub type A2aStream = Pin<Box<dyn Stream<Item = Result<Value, String>> + Send>>;
+
+/// The A2A operations the driver needs, behind a trait. Owned args keep the
+/// returned futures `'static` + `Send` (same pattern as `ServiceTransport`).
+pub trait A2aTransport: Send + Sync + 'static {
+    /// GET the agent card. `token` is used only for the 401-retry.
+    fn fetch_card(
+        &self,
+        url: String,
+        token: Option<String>,
+    ) -> impl std::future::Future<Output = Result<Value, String>> + Send;
+
+    /// POST a JSON-RPC call; returns the `result` (envelope error mapped to `Err`).
+    fn call(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> impl std::future::Future<Output = Result<Value, String>> + Send;
+
+    /// POST `message/stream`; returns a stream of per-frame `result` values.
+    fn stream(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> impl std::future::Future<Output = Result<A2aStream, String>> + Send;
+}
+
+/// Production transport backed by `reqwest`. Two clients: a 30s-timeout client
+/// for card fetch + unary calls, and a no-overall-timeout client for the SSE
+/// stream (an active stream's data keeps it alive; a total timeout would cut it).
+pub struct HttpA2aTransport {
+    unary: reqwest::Client,
+    streaming: reqwest::Client,
+}
+
+impl Default for HttpA2aTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpA2aTransport {
+    pub fn new() -> Self {
+        let unary = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        let streaming = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        Self { unary, streaming }
+    }
+}
+
+impl A2aTransport for HttpA2aTransport {
+    async fn fetch_card(&self, url: String, token: Option<String>) -> Result<Value, String> {
+        // Card fetch is an unauthenticated GET; if it 401s AND we have a token,
+        // retry once with the bearer token (covers protected cards).
+        let resp = self
+            .unary
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("Could not reach the agent: {e}"))?;
+        let status = resp.status();
+        if status.as_u16() == 401 {
+            if let Some(t) = token {
+                let resp2 = self
+                    .unary
+                    .get(&url)
+                    .bearer_auth(t)
+                    .send()
+                    .await
+                    .map_err(|e| format!("Could not reach the agent: {e}"))?;
+                if !resp2.status().is_success() {
+                    return Err(format!("HTTP {}", resp2.status().as_u16()));
+                }
+                return resp2
+                    .json()
+                    .await
+                    .map_err(|e| format!("The agent card was not valid JSON: {e}"));
+            }
+            return Err("HTTP 401".to_string());
+        }
+        if !status.is_success() {
+            return Err(format!("HTTP {}", status.as_u16()));
+        }
+        resp.json()
+            .await
+            .map_err(|e| format!("The agent card was not valid JSON: {e}"))
+    }
+
+    async fn call(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> Result<Value, String> {
+        let req = JsonRpcRequest::new(&method, params);
+        let mut builder = self.unary.post(&endpoint).json(&req);
+        if let Some(t) = token {
+            builder = builder.bearer_auth(t);
+        }
+        let resp = builder
+            .send()
+            .await
+            .map_err(|e| format!("request failed: {e}"))?;
+        // A2A returns JSON-RPC envelopes even on some non-2xx; parse the body and
+        // let envelope error-handling win, falling back to the HTTP status.
+        let status = resp.status();
+        let body: Value = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(format!("HTTP {}: {e}", status.as_u16()));
+            }
+        };
+        parse_jsonrpc_envelope(&body)
+    }
+
+    async fn stream(
+        &self,
+        endpoint: String,
+        token: Option<String>,
+        method: String,
+        params: Value,
+    ) -> Result<A2aStream, String> {
+        let req = JsonRpcRequest::new(&method, params);
+        let mut builder = self
+            .streaming
+            .post(&endpoint)
+            .header("Accept", "text/event-stream")
+            .json(&req);
+        if let Some(t) = token {
+            builder = builder.bearer_auth(t);
+        }
+        let resp = builder
+            .send()
+            .await
+            .map_err(|e| format!("stream request failed: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("HTTP {}", resp.status().as_u16()));
+        }
+
+        struct StreamState<S> {
+            inner: S,
+            parser: SseParser,
+            queue: std::collections::VecDeque<String>,
+        }
+        let state = StreamState {
+            inner: resp.bytes_stream(),
+            parser: SseParser::new(),
+            queue: std::collections::VecDeque::new(),
+        };
+
+        let s = futures_util::stream::unfold(state, |mut st| async move {
+            loop {
+                // Drain already-parsed frames first, skipping non-JSON garbage.
+                while let Some(data) = st.queue.pop_front() {
+                    match serde_json::from_str::<Value>(&data) {
+                        Ok(env) => return Some((parse_jsonrpc_envelope(&env), st)),
+                        Err(_) => continue, // tolerate garbage frames
+                    }
+                }
+                match st.inner.next().await {
+                    Some(Ok(bytes)) => {
+                        let text = String::from_utf8_lossy(&bytes);
+                        for data in st.parser.feed(&text) {
+                            st.queue.push_back(data);
+                        }
+                        continue;
+                    }
+                    Some(Err(e)) => {
+                        return Some((Err(format!("stream error: {e}")), st));
+                    }
+                    None => return None,
+                }
+            }
+        });
+        Ok(Box::pin(s))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driver protocol loop (the RemoteDriver's core — transport-agnostic, testable)
+// ---------------------------------------------------------------------------
+
+/// Terminal outcome of a remote run, mapped to a `RunStatus` by the driver.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteOutcome {
+    /// `completed` → `Finished { code: 0 }`.
+    Finished,
+    /// Any error / `failed` / `rejected` / unsupported-multiturn / timeout.
+    Failed(String),
+    /// `canceled` on the server, or a local stop request.
+    Stopped,
+}
+
+/// Production timings.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(2);
+pub const POLL_CAP: Duration = Duration::from_secs(15 * 60);
+
+/// Drive one remote run to a terminal outcome. `on_output` receives each new
+/// text chunk (streamed live by the driver into the run panel). `kill_rx`
+/// requests a stop. `poll_interval`/`poll_cap` are injectable for tests.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_remote_protocol<T, F>(
+    transport: &T,
+    endpoint: &str,
+    token: Option<String>,
+    instruction: &str,
+    streaming: bool,
+    kill_rx: &mut mpsc::UnboundedReceiver<()>,
+    on_output: &mut F,
+    poll_interval: Duration,
+    poll_cap: Duration,
+) -> RemoteOutcome
+where
+    T: A2aTransport,
+    F: FnMut(&str) + Send,
+{
+    let deadline = Instant::now() + poll_cap;
+    let mut dedup = TextDedup::new();
+
+    if streaming {
+        match stream_phase(
+            transport,
+            endpoint,
+            &token,
+            instruction,
+            kill_rx,
+            &mut dedup,
+            on_output,
+        )
+        .await
+        {
+            StreamPhase::Terminal(outcome) => return outcome,
+            StreamPhase::Stopped => return RemoteOutcome::Stopped,
+            StreamPhase::Fallback(task_id) => {
+                // Stream broke mid-way but we have a task id — degrade to polling.
+                return poll_phase(
+                    transport,
+                    endpoint,
+                    &token,
+                    &task_id,
+                    kill_rx,
+                    &mut dedup,
+                    on_output,
+                    poll_interval,
+                    deadline,
+                )
+                .await;
+            }
+        }
+    }
+
+    // Non-streaming: message/send, then dispatch.
+    let result = match transport
+        .call(
+            endpoint.to_string(),
+            token.clone(),
+            METHOD_MESSAGE_SEND.to_string(),
+            build_send_params(instruction),
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return RemoteOutcome::Failed(e),
+    };
+
+    match dispatch_send_result(&result) {
+        SendDispatch::DirectMessage(chunks) => {
+            for c in chunks {
+                if let Some(text) = dedup.push(&c) {
+                    on_output(&text);
+                }
+            }
+            RemoteOutcome::Finished
+        }
+        SendDispatch::UnusableTask => {
+            RemoteOutcome::Failed("the server returned a task with no id".to_string())
+        }
+        SendDispatch::Task { id, initial_text } => {
+            for c in initial_text {
+                if let Some(text) = dedup.push(&c) {
+                    on_output(&text);
+                }
+            }
+            // The initial response may already be terminal.
+            if let Some(state) = task_state(&result) {
+                if let Some(outcome) = terminal_outcome(&state, task_status_message(&result)) {
+                    return outcome;
+                }
+            }
+            poll_phase(
+                transport,
+                endpoint,
+                &token,
+                &id,
+                kill_rx,
+                &mut dedup,
+                on_output,
+                poll_interval,
+                deadline,
+            )
+            .await
+        }
+    }
+}
+
+/// Convert a state string into a terminal [`RemoteOutcome`], or `None` if the
+/// state is non-terminal (keep going). Folds the `NeedsInput` case into the
+/// actionable "multi-turn isn't supported yet" failure.
+fn terminal_outcome(state: &str, server_message: Option<String>) -> Option<RemoteOutcome> {
+    match classify_state(state, server_message) {
+        StateClass::NonTerminal | StateClass::Unknown => None,
+        StateClass::Finished => Some(RemoteOutcome::Finished),
+        StateClass::Failed(msg) => Some(RemoteOutcome::Failed(match msg {
+            Some(m) => format!("the agent reported: {m}"),
+            None => "the agent reported a failure".to_string(),
+        })),
+        StateClass::Stopped => Some(RemoteOutcome::Stopped),
+        StateClass::NeedsInput => Some(RemoteOutcome::Failed(
+            "the agent needs interactive input — multi-turn isn't supported yet".to_string(),
+        )),
+    }
+}
+
+/// Poll `tasks/get` every `poll_interval` until the task is terminal, the poll
+/// cap (`deadline`) is hit, or a stop is requested (→ `tasks/cancel`).
+#[allow(clippy::too_many_arguments)]
+async fn poll_phase<T, F>(
+    transport: &T,
+    endpoint: &str,
+    token: &Option<String>,
+    task_id: &str,
+    kill_rx: &mut mpsc::UnboundedReceiver<()>,
+    dedup: &mut TextDedup,
+    on_output: &mut F,
+    poll_interval: Duration,
+    deadline: Instant,
+) -> RemoteOutcome
+where
+    T: A2aTransport,
+    F: FnMut(&str) + Send,
+{
+    loop {
+        // Wait one interval OR a stop request. A stop request wins immediately.
+        tokio::select! {
+            biased;
+            _ = kill_rx.recv() => {
+                let _ = transport
+                    .call(
+                        endpoint.to_string(),
+                        token.clone(),
+                        METHOD_TASKS_CANCEL.to_string(),
+                        json!({ "id": task_id }),
+                    )
+                    .await; // idempotent; TaskNotCancelable tolerated
+                return RemoteOutcome::Stopped;
+            }
+            _ = tokio::time::sleep(poll_interval) => {}
+        }
+
+        if Instant::now() >= deadline {
+            return RemoteOutcome::Failed(
+                "timed out; the task may still be running on the server".to_string(),
+            );
+        }
+
+        let task = match transport
+            .call(
+                endpoint.to_string(),
+                token.clone(),
+                METHOD_TASKS_GET.to_string(),
+                json!({ "id": task_id, "historyLength": 0 }),
+            )
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => return RemoteOutcome::Failed(e),
+        };
+
+        for c in task_text_chunks(&task) {
+            if let Some(text) = dedup.push(&c) {
+                on_output(&text);
+            }
+        }
+
+        if let Some(state) = task_state(&task) {
+            if let Some(outcome) = terminal_outcome(&state, task_status_message(&task)) {
+                return outcome;
+            }
+        }
+    }
+}
+
+/// Result of the streaming phase.
+enum StreamPhase {
+    Terminal(RemoteOutcome),
+    Stopped,
+    /// Stream errored mid-way but a task id is known — the caller polls instead.
+    Fallback(String),
+}
+
+/// Consume `message/stream` frames, appending artifact/status text live, until a
+/// `final:true` / terminal state closes it, a stop is requested, or the stream
+/// errors (→ fallback poll if a task id was seen, else a failure).
+async fn stream_phase<T, F>(
+    transport: &T,
+    endpoint: &str,
+    token: &Option<String>,
+    instruction: &str,
+    kill_rx: &mut mpsc::UnboundedReceiver<()>,
+    dedup: &mut TextDedup,
+    on_output: &mut F,
+) -> StreamPhase
+where
+    T: A2aTransport,
+    F: FnMut(&str) + Send,
+{
+    let mut stream = match transport
+        .stream(
+            endpoint.to_string(),
+            token.clone(),
+            METHOD_MESSAGE_STREAM.to_string(),
+            build_send_params(instruction),
+        )
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => return StreamPhase::Terminal(RemoteOutcome::Failed(e)),
+    };
+
+    let mut task_id: Option<String> = None;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = kill_rx.recv() => {
+                if let Some(id) = &task_id {
+                    let _ = transport
+                        .call(
+                            endpoint.to_string(),
+                            token.clone(),
+                            METHOD_TASKS_CANCEL.to_string(),
+                            json!({ "id": id }),
+                        )
+                        .await;
+                }
+                return StreamPhase::Stopped;
+            }
+            frame = stream.next() => {
+                match frame {
+                    Some(Ok(result)) => {
+                        // Track a task id for cancel / fallback.
+                        if task_id.is_none() {
+                            if let Some(id) = result
+                                .get("taskId")
+                                .or_else(|| result.get("id"))
+                                .and_then(Value::as_str)
+                            {
+                                if !id.is_empty() {
+                                    task_id = Some(id.to_string());
+                                }
+                            }
+                        }
+                        // Append any text (artifact-update carries `artifact`,
+                        // status-update carries `status.message`, and a Task/Message
+                        // frame carries its own parts).
+                        for c in frame_text(&result) {
+                            if let Some(text) = dedup.push(&c) {
+                                on_output(&text);
+                            }
+                        }
+                        // Terminal state or explicit final flag closes the stream.
+                        if let Some(state) = task_state(&result) {
+                            if let Some(outcome) =
+                                terminal_outcome(&state, task_status_message(&result))
+                            {
+                                return StreamPhase::Terminal(outcome);
+                            }
+                        }
+                        if result.get("final").and_then(Value::as_bool) == Some(true) {
+                            return StreamPhase::Terminal(RemoteOutcome::Finished);
+                        }
+                    }
+                    Some(Err(e)) => {
+                        // Mid-stream error: degrade to polling if we know the task.
+                        match &task_id {
+                            Some(id) => return StreamPhase::Fallback(id.clone()),
+                            None => {
+                                return StreamPhase::Terminal(RemoteOutcome::Failed(e));
+                            }
+                        }
+                    }
+                    None => {
+                        // Stream ended without a terminal frame. Treat as done if
+                        // we streamed something; otherwise fall back / finish.
+                        return match &task_id {
+                            Some(id) => StreamPhase::Fallback(id.clone()),
+                            None => StreamPhase::Terminal(RemoteOutcome::Finished),
+                        };
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Text carried by a single stream frame (artifact-update, status-update, or a
+/// bare Task/Message frame).
+fn frame_text(result: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    // artifact-update: { artifact: { parts: [...] } }
+    if let Some(art) = result.get("artifact") {
+        out.extend(parts_text(art.get("parts")));
+    }
+    // status-update / Task: { status: { message: { parts } } } + artifacts
+    out.extend(task_text_chunks(result));
+    // bare Message frame: { parts: [...] }
+    if result.get("kind").and_then(Value::as_str) == Some("message") {
+        out.extend(message_text(result));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- card URL derivation ------------------------------------------------
+
+    #[test]
+    fn well_known_url_derived_from_base() {
+        assert_eq!(
+            well_known_card_url("https://agent.example.com"),
+            "https://agent.example.com/.well-known/agent-card.json"
+        );
+        assert_eq!(
+            well_known_card_url("https://agent.example.com/"),
+            "https://agent.example.com/.well-known/agent-card.json"
+        );
+    }
+
+    #[test]
+    fn well_known_url_accepts_full_card_url_verbatim() {
+        let full = "https://x.example.com/custom/agent-card.json";
+        assert_eq!(well_known_card_url(full), full);
+        let wk = "https://x.example.com/.well-known/agent-card.json";
+        assert_eq!(well_known_card_url(wk), wk);
+    }
+
+    // ---- card parse: both shapes -------------------------------------------
+
+    #[test]
+    fn parse_card_v03_shape() {
+        let v = json!({
+            "protocolVersion": "0.3.0",
+            "name": "V03 Agent",
+            "version": "1.0.0",
+            "url": "https://a.example.com/rpc",
+            "preferredTransport": "JSONRPC",
+            "capabilities": { "streaming": true },
+            "additionalInterfaces": [
+                { "url": "https://a.example.com/grpc", "transport": "GRPC" }
+            ],
+            "securitySchemes": { "bearer": { "type": "http", "scheme": "bearer" } },
+            "skills": [ { "id": "code", "name": "Coding" } ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        assert_eq!(card.name, "V03 Agent");
+        assert_eq!(card.version, "1.0.0");
+        assert!(card.streaming);
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://a.example.com/rpc"
+        );
+        assert_eq!(card.auth_schemes, vec!["http".to_string()]);
+        assert_eq!(card.skills.len(), 1);
+        assert_eq!(card.skills[0].id, "code");
+    }
+
+    #[test]
+    fn parse_card_v03_minimal_url_only_defaults_jsonrpc() {
+        // A minimal v0.3 card with just `url` (no preferredTransport) must
+        // resolve as JSONRPC per spec.
+        let v = json!({ "name": "Min", "version": "0.1", "url": "https://m.example.com/a2a" });
+        let card = parse_agent_card(&v).unwrap();
+        assert!(!card.streaming);
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://m.example.com/a2a"
+        );
+    }
+
+    #[test]
+    fn parse_card_v10_shape() {
+        let v = json!({
+            "protocolVersion": "1.0.0",
+            "name": "V10 Agent",
+            "version": "2.0.0",
+            "capabilities": { "streaming": false },
+            "supportedInterfaces": [
+                { "url": "https://b.example.com/grpc", "protocolBinding": "GRPC", "protocolVersion": "1.0.0" },
+                { "url": "https://b.example.com/rpc", "protocolBinding": "JSONRPC", "protocolVersion": "1.0.0" }
+            ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        assert_eq!(card.name, "V10 Agent");
+        assert!(!card.streaming);
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://b.example.com/rpc"
+        );
+    }
+
+    // ---- endpoint selection -------------------------------------------------
+
+    #[test]
+    fn endpoint_selection_honors_preferred_order() {
+        // Two JSONRPC interfaces: the first (preferred top-level url) wins.
+        let v = json!({
+            "name": "x", "version": "1",
+            "url": "https://first.example.com/rpc",
+            "preferredTransport": "JSONRPC",
+            "additionalInterfaces": [
+                { "url": "https://second.example.com/rpc", "transport": "JSONRPC" }
+            ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        assert_eq!(
+            card.select_jsonrpc_endpoint().unwrap(),
+            "https://first.example.com/rpc"
+        );
+    }
+
+    #[test]
+    fn endpoint_selection_errors_when_no_jsonrpc() {
+        let v = json!({
+            "name": "x", "version": "1",
+            "supportedInterfaces": [
+                { "url": "https://g.example.com", "protocolBinding": "GRPC" }
+            ]
+        });
+        let card = parse_agent_card(&v).unwrap();
+        let err = card.select_jsonrpc_endpoint().unwrap_err();
+        assert!(err.contains("JSON-RPC"));
+    }
+
+    #[test]
+    fn transport_token_normalizes_variants() {
+        assert!(is_jsonrpc("JSONRPC"));
+        assert!(is_jsonrpc("jsonrpc"));
+        assert!(is_jsonrpc("JSON-RPC"));
+        assert!(!is_jsonrpc("GRPC"));
+        assert!(!is_jsonrpc("HTTP+JSON"));
+    }
+
+    // ---- JSON-RPC envelope --------------------------------------------------
+
+    #[test]
+    fn envelope_error_wins_over_result() {
+        let v = json!({ "jsonrpc": "2.0", "id": "1",
+            "error": { "code": -32001, "message": "Task not found" },
+            "result": null });
+        let err = parse_jsonrpc_envelope(&v).unwrap_err();
+        assert_eq!(err, "-32001: Task not found");
+    }
+
+    #[test]
+    fn envelope_returns_result() {
+        let v = json!({ "jsonrpc": "2.0", "id": "1", "result": { "kind": "task", "id": "t1" } });
+        let r = parse_jsonrpc_envelope(&v).unwrap();
+        assert_eq!(r.get("id").unwrap(), "t1");
+    }
+
+    #[test]
+    fn envelope_missing_both_errors() {
+        let v = json!({ "jsonrpc": "2.0", "id": "1" });
+        assert!(parse_jsonrpc_envelope(&v).is_err());
+    }
+
+    // ---- send-result dispatch ----------------------------------------------
+
+    #[test]
+    fn dispatch_direct_message() {
+        let result = json!({
+            "kind": "message",
+            "role": "agent",
+            "parts": [ { "kind": "text", "text": "hello there" } ]
+        });
+        assert_eq!(
+            dispatch_send_result(&result),
+            SendDispatch::DirectMessage(vec!["hello there".to_string()])
+        );
+    }
+
+    #[test]
+    fn dispatch_task_with_id() {
+        let result = json!({
+            "kind": "task",
+            "id": "task-42",
+            "status": { "state": "working" }
+        });
+        assert_eq!(
+            dispatch_send_result(&result),
+            SendDispatch::Task {
+                id: "task-42".to_string(),
+                initial_text: vec![]
+            }
+        );
+    }
+
+    #[test]
+    fn dispatch_task_without_kind_via_structure() {
+        // No `kind` but has status+id → task.
+        let result = json!({ "id": "t9", "status": { "state": "submitted" } });
+        assert!(matches!(
+            dispatch_send_result(&result),
+            SendDispatch::Task { .. }
+        ));
+    }
+
+    #[test]
+    fn dispatch_task_without_id_is_unusable() {
+        let result = json!({ "kind": "task", "status": { "state": "working" } });
+        assert_eq!(dispatch_send_result(&result), SendDispatch::UnusableTask);
+    }
+
+    // ---- part / task text ---------------------------------------------------
+
+    #[test]
+    fn non_text_parts_are_summarized() {
+        let file = json!({ "kind": "file", "file": { "name": "out.txt" } });
+        assert_eq!(part_to_text(&file), Some("[file: out.txt]".to_string()));
+        let data = json!({ "kind": "data", "data": { "x": 1 } });
+        assert_eq!(part_to_text(&data), Some("[data]".to_string()));
+        let text = json!({ "kind": "text", "text": "hi" });
+        assert_eq!(part_to_text(&text), Some("hi".to_string()));
+    }
+
+    #[test]
+    fn task_text_gathers_status_and_artifacts() {
+        let task = json!({
+            "id": "t",
+            "status": { "state": "working", "message": { "parts": [ { "kind": "text", "text": "step 1" } ] } },
+            "artifacts": [
+                { "parts": [ { "kind": "text", "text": "result A" } ] },
+                { "parts": [ { "kind": "text", "text": "result B" } ] }
+            ]
+        });
+        assert_eq!(
+            task_text_chunks(&task),
+            vec![
+                "step 1".to_string(),
+                "result A".to_string(),
+                "result B".to_string()
+            ]
+        );
+    }
+
+    // ---- state mapping table -----------------------------------------------
+
+    #[test]
+    fn state_mapping_table() {
+        assert_eq!(classify_state("submitted", None), StateClass::NonTerminal);
+        assert_eq!(classify_state("working", None), StateClass::NonTerminal);
+        assert_eq!(classify_state("completed", None), StateClass::Finished);
+        assert_eq!(
+            classify_state("failed", Some("boom".into())),
+            StateClass::Failed(Some("boom".into()))
+        );
+        assert_eq!(classify_state("rejected", None), StateClass::Failed(None));
+        assert_eq!(classify_state("canceled", None), StateClass::Stopped);
+        assert_eq!(
+            classify_state("input-required", None),
+            StateClass::NeedsInput
+        );
+        assert_eq!(
+            classify_state("auth-required", None),
+            StateClass::NeedsInput
+        );
+        assert_eq!(classify_state("weird", None), StateClass::Unknown);
+    }
+
+    #[test]
+    fn terminal_outcome_folds_needs_input_to_failure() {
+        assert_eq!(terminal_outcome("submitted", None), None);
+        assert_eq!(
+            terminal_outcome("completed", None),
+            Some(RemoteOutcome::Finished)
+        );
+        assert_eq!(
+            terminal_outcome("canceled", None),
+            Some(RemoteOutcome::Stopped)
+        );
+        match terminal_outcome("input-required", None) {
+            Some(RemoteOutcome::Failed(m)) => assert!(m.contains("multi-turn")),
+            other => panic!("unexpected: {other:?}"),
+        }
+        match terminal_outcome("failed", Some("disk full".into())) {
+            Some(RemoteOutcome::Failed(m)) => assert!(m.contains("disk full")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    // ---- dedupe -------------------------------------------------------------
+
+    #[test]
+    fn dedup_emits_each_chunk_once() {
+        let mut d = TextDedup::new();
+        assert_eq!(d.push("a"), Some("a".to_string()));
+        assert_eq!(d.push("a"), None);
+        assert_eq!(d.push("b"), Some("b".to_string()));
+        assert_eq!(d.push(""), None);
+    }
+
+    // ---- SSE parser ---------------------------------------------------------
+
+    #[test]
+    fn sse_single_frame() {
+        let mut p = SseParser::new();
+        let out = p.feed("data: {\"a\":1}\n\n");
+        assert_eq!(out, vec!["{\"a\":1}".to_string()]);
+    }
+
+    #[test]
+    fn sse_multiline_data_joined_with_newline() {
+        let mut p = SseParser::new();
+        let out = p.feed("data: line1\ndata: line2\n\n");
+        assert_eq!(out, vec!["line1\nline2".to_string()]);
+    }
+
+    #[test]
+    fn sse_comments_and_crlf() {
+        let mut p = SseParser::new();
+        // `:` comment line is ignored; CRLF line endings are handled.
+        let out = p.feed(": keep-alive\r\ndata: {\"ok\":true}\r\n\r\n");
+        assert_eq!(out, vec!["{\"ok\":true}".to_string()]);
+    }
+
+    #[test]
+    fn sse_event_split_across_chunks() {
+        let mut p = SseParser::new();
+        assert!(p.feed("data: {\"par").is_empty());
+        assert!(p.feed("t\":1}").is_empty());
+        let out = p.feed("\n\n");
+        assert_eq!(out, vec!["{\"part\":1}".to_string()]);
+    }
+
+    #[test]
+    fn sse_two_frames_one_chunk() {
+        let mut p = SseParser::new();
+        let out = p.feed("data: a\n\ndata: b\n\n");
+        assert_eq!(out, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn sse_garbage_is_returned_and_parses_none() {
+        // The parser returns the payload even if it's not JSON — the consumer's
+        // serde parse then drops it. Here we assert the raw payload comes through.
+        let mut p = SseParser::new();
+        let out = p.feed("data: not json\n\n");
+        assert_eq!(out, vec!["not json".to_string()]);
+        assert!(serde_json::from_str::<Value>(&out[0]).is_err());
+    }
+
+    #[test]
+    fn request_ids_are_unique_and_shaped() {
+        let a = new_request_id();
+        let b = new_request_id();
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 36);
+        assert_eq!(a.chars().filter(|c| *c == '-').count(), 4);
+    }
+
+    // ---- driver protocol loop against a MOCK transport (no network) ---------
+
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex;
+
+    /// A scriptable, no-network [`A2aTransport`] for driver-flow tests. `call`
+    /// dispatches on method; `tasks/get` walks a queue (repeating its last entry
+    /// so a poll loop can spin), `tasks/cancel` is counted.
+    struct MockTransport {
+        send_result: Mutex<Option<Result<Value, String>>>,
+        get_results: Mutex<VecDeque<Result<Value, String>>>,
+        stream_frames: Mutex<Option<Vec<Result<Value, String>>>>,
+        cancel_calls: AtomicUsize,
+        get_calls: AtomicUsize,
+    }
+
+    impl MockTransport {
+        fn new() -> Self {
+            Self {
+                send_result: Mutex::new(None),
+                get_results: Mutex::new(VecDeque::new()),
+                stream_frames: Mutex::new(None),
+                cancel_calls: AtomicUsize::new(0),
+                get_calls: AtomicUsize::new(0),
+            }
+        }
+        fn with_send(self, r: Result<Value, String>) -> Self {
+            *self.send_result.lock().unwrap() = Some(r);
+            self
+        }
+        fn with_gets(self, rs: Vec<Result<Value, String>>) -> Self {
+            *self.get_results.lock().unwrap() = rs.into();
+            self
+        }
+        fn with_stream(self, frames: Vec<Result<Value, String>>) -> Self {
+            *self.stream_frames.lock().unwrap() = Some(frames);
+            self
+        }
+    }
+
+    impl A2aTransport for MockTransport {
+        fn fetch_card(
+            &self,
+            _url: String,
+            _token: Option<String>,
+        ) -> impl std::future::Future<Output = Result<Value, String>> + Send {
+            let card = json!({ "name": "Mock", "version": "1", "url": "https://mock/rpc" });
+            async move { Ok(card) }
+        }
+
+        fn call(
+            &self,
+            _endpoint: String,
+            _token: Option<String>,
+            method: String,
+            _params: Value,
+        ) -> impl std::future::Future<Output = Result<Value, String>> + Send {
+            let result = if method == METHOD_MESSAGE_SEND {
+                self.send_result
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap_or_else(|| Err("no send scripted".to_string()))
+            } else if method == METHOD_TASKS_GET {
+                self.get_calls.fetch_add(1, Ordering::Relaxed);
+                let mut q = self.get_results.lock().unwrap();
+                if q.len() > 1 {
+                    q.pop_front().unwrap()
+                } else {
+                    q.front()
+                        .cloned()
+                        .unwrap_or_else(|| Err("no get scripted".to_string()))
+                }
+            } else if method == METHOD_TASKS_CANCEL {
+                self.cancel_calls.fetch_add(1, Ordering::Relaxed);
+                Ok(json!({}))
+            } else {
+                Err(format!("unexpected method {method}"))
+            };
+            async move { result }
+        }
+
+        fn stream(
+            &self,
+            _endpoint: String,
+            _token: Option<String>,
+            _method: String,
+            _params: Value,
+        ) -> impl std::future::Future<Output = Result<A2aStream, String>> + Send {
+            let frames = self.stream_frames.lock().unwrap().clone();
+            async move {
+                match frames {
+                    Some(fs) => {
+                        let s = futures_util::stream::iter(fs);
+                        Ok(Box::pin(s) as A2aStream)
+                    }
+                    None => Err("no stream scripted".to_string()),
+                }
+            }
+        }
+    }
+
+    /// Run a future to completion on a current-thread runtime with the time
+    /// driver enabled (the repo enables the tokio `rt`+`time` features but uses
+    /// no `#[tokio::test]`, so we build the runtime explicitly).
+    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(fut)
+    }
+
+    fn tiny() -> (Duration, Duration) {
+        (Duration::from_millis(1), Duration::from_secs(60))
+    }
+
+    #[test]
+    fn driver_direct_message_happy_path() {
+        block_on(async {
+            let t = MockTransport::new().with_send(Ok(json!({
+                "kind": "message",
+                "parts": [ { "kind": "text", "text": "all done" } ]
+            })));
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "do it",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Finished);
+            assert_eq!(out, vec!["all done".to_string()]);
+        });
+    }
+
+    #[test]
+    fn driver_task_poll_until_completed() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "submitted" } }),
+                ))
+                .with_gets(vec![
+                    Ok(json!({ "id": "t1", "status": { "state": "working" } })),
+                    Ok(json!({
+                        "id": "t1",
+                        "status": { "state": "completed" },
+                        "artifacts": [ { "parts": [ { "kind": "text", "text": "final answer" } ] } ]
+                    })),
+                ]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Finished);
+            assert_eq!(out, vec!["final answer".to_string()]);
+            assert!(t.get_calls.load(Ordering::Relaxed) >= 2);
+        });
+    }
+
+    #[test]
+    fn driver_task_failed_includes_server_message() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                .with_gets(vec![Ok(json!({
+                    "id": "t1",
+                    "status": {
+                        "state": "failed",
+                        "message": { "parts": [ { "kind": "text", "text": "out of credits" } ] }
+                    }
+                }))]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("out of credits"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_cancel_mid_poll_calls_tasks_cancel_and_stops() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                // Never terminal — the poll would spin until we cancel.
+                .with_gets(vec![Ok(
+                    json!({ "id": "t1", "status": { "state": "working" } }),
+                )]);
+            let (tx, mut rx) = mpsc::unbounded_channel::<()>();
+            tx.send(()).unwrap(); // request a stop before the first poll wait
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Stopped);
+            assert_eq!(t.cancel_calls.load(Ordering::Relaxed), 1);
+        });
+    }
+
+    #[test]
+    fn driver_input_required_is_actionable_failure() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                .with_gets(vec![Ok(
+                    json!({ "id": "t1", "status": { "state": "input-required" } }),
+                )]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("multi-turn"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_poll_cap_times_out() {
+        block_on(async {
+            let t = MockTransport::new()
+                .with_send(Ok(
+                    json!({ "kind": "task", "id": "t1", "status": { "state": "working" } }),
+                ))
+                .with_gets(vec![Ok(
+                    json!({ "id": "t1", "status": { "state": "working" } }),
+                )]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            // Zero cap: the first poll wait immediately exceeds the deadline.
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                Duration::from_millis(1),
+                Duration::from_millis(0),
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("timed out"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_send_jsonrpc_error_fails() {
+        block_on(async {
+            let t = MockTransport::new().with_send(Err("-32600: Invalid Request".to_string()));
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                false,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            match outcome {
+                RemoteOutcome::Failed(m) => assert!(m.contains("Invalid Request"), "got: {m}"),
+                other => panic!("expected Failed, got {other:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn driver_streaming_happy_path() {
+        block_on(async {
+            let t = MockTransport::new().with_stream(vec![
+                Ok(json!({
+                    "kind": "artifact-update",
+                    "taskId": "t1",
+                    "artifact": { "parts": [ { "kind": "text", "text": "chunk one" } ] }
+                })),
+                Ok(json!({
+                    "kind": "status-update",
+                    "taskId": "t1",
+                    "status": { "state": "completed" },
+                    "final": true
+                })),
+            ]);
+            let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+            let mut out: Vec<String> = Vec::new();
+            let mut on = |s: &str| out.push(s.to_string());
+            let (pi, pc) = tiny();
+            let outcome = run_remote_protocol(
+                &t,
+                "https://mock/rpc",
+                None,
+                "go",
+                true,
+                &mut rx,
+                &mut on,
+                pi,
+                pc,
+            )
+            .await;
+            assert_eq!(outcome, RemoteOutcome::Finished);
+            assert_eq!(out, vec!["chunk one".to_string()]);
+        });
+    }
+}

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1313,31 +1313,38 @@ pub(crate) async fn finish_dictation(
         .map(|m| m.kind == AiModeKind::Command)
         .unwrap_or(false);
 
-    // Flow OS increment 2: a CLI agent does NOT run the persona-LLM transform or
-    // inject anything — it drives a real coding-agent subprocess. Hand the
-    // transcript to the AgentRunManager (which spawns the process + a detached
-    // streaming task and returns at once) and RETURN IMMEDIATELY so the
+    // Flow OS increment 2/3: a CLI or REMOTE (A2A) agent does NOT run the
+    // persona-LLM transform or inject anything — it drives a real coding-agent
+    // subprocess (Cli) or a remote A2A server (Remote) behind the SAME run seam.
+    // Hand the transcript to the AgentRunManager (which registers the run + a
+    // detached driver task and returns at once) and RETURN IMMEDIATELY so the
     // coordinator's Processing stage ends promptly and dictation is never
     // blocked by a long agent run. Prompt agents and normal dictation fall
     // through to the unchanged increment-1 path below.
     if let Some(agent) = agent.as_ref() {
-        if agent.kind == crate::settings::AgentKind::Cli {
+        use crate::settings::AgentKind;
+        if agent.kind == AgentKind::Cli || agent.kind == AgentKind::Remote {
+            let kind_label = if agent.kind == AgentKind::Remote {
+                "remote"
+            } else {
+                "CLI"
+            };
             let instruction = raw_text.trim().to_string();
             if instruction.is_empty() {
                 debug!(
-                    "CLI agent '{}' triggered with an empty transcript; skipping run",
-                    agent.id
+                    "{} agent '{}' triggered with an empty transcript; skipping run",
+                    kind_label, agent.id
                 );
             } else if let Some(mgr) = ah.try_state::<Arc<AgentRunManager>>() {
                 let run_id = mgr.inner().start(&ah, agent.clone(), instruction);
                 debug!(
-                    "Started CLI agent run '{}' for agent '{}' (project: '{}')",
-                    run_id, agent.id, agent.project_path
+                    "Started {} agent run '{}' for agent '{}'",
+                    kind_label, run_id, agent.id
                 );
             } else {
                 error!(
-                    "AgentRunManager not initialized; cannot start CLI agent '{}'",
-                    agent.id
+                    "AgentRunManager not initialized; cannot start {} agent '{}'",
+                    kind_label, agent.id
                 );
             }
             utils::hide_recording_overlay(&ah);
@@ -2253,6 +2260,11 @@ mod tests {
             project_path: String::new(),
             output_sinks: vec![AgentOutputSink::Panel],
             prompt_via: PromptDelivery::Stdin,
+            remote_url: String::new(),
+            remote_endpoint: String::new(),
+            remote_card_name: String::new(),
+            remote_card_version: String::new(),
+            remote_streaming: false,
         }
     }
 

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -210,6 +210,11 @@ mod tests {
             project_path: String::new(),
             output_sinks: vec![AgentOutputSink::Panel],
             prompt_via: PromptDelivery::Stdin,
+            remote_url: String::new(),
+            remote_endpoint: String::new(),
+            remote_card_name: String::new(),
+            remote_card_version: String::new(),
+            remote_streaming: false,
         }
     }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod backends;
 pub mod history;
 pub mod meetings;
 pub mod models;
+pub mod service;
 pub mod transcription;
 
 use crate::settings::{get_settings, write_settings, AppSettings, LogLevel};

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod backends;
 pub mod history;
 pub mod meetings;
 pub mod models;
+pub mod remote_agents;
 pub mod service;
 pub mod transcription;
 

--- a/src-tauri/src/commands/remote_agents.rs
+++ b/src-tauri/src/commands/remote_agents.rs
@@ -1,0 +1,140 @@
+//! Flow OS increment 3 — commands for **remote (A2A) agents**.
+//!
+//! These manage the A2A-specific lifecycle that the generic agent commands
+//! (`create_agent`/`update_agent`/`delete_agent` in `commands::agents`) don't
+//! cover: fetching + resolving an agent card, and a lightweight reachability
+//! test. Everything else (create/update/delete, hotkey binding, the per-agent
+//! keyring token via `set_api_key("agent", id, …)`) is reused unchanged.
+//!
+//! The token lives in the OS keyring (scope `"agent"`, account = agent id) and
+//! is never written to the settings store; `delete_agent` already cleans it up.
+
+use tauri::AppHandle;
+
+use crate::a2a::{self, A2aTransport, AgentCardSummary, HttpA2aTransport};
+use crate::settings::{self, AgentDefinition};
+
+/// Map a raw fetch/transport error into a friendly, user-facing message
+/// (mirrors the `service.rs` status-mapping pattern). The `no-JSON-RPC` and
+/// `not-A2A` cases already carry clear messages and pass through.
+fn friendly_card_error(e: &str) -> String {
+    if e.contains("HTTP 401") {
+        "This agent needs a token. Add one in the token field below, then fetch again.".to_string()
+    } else if e.contains("HTTP 404") {
+        "No agent card was found at that URL. Check the address.".to_string()
+    } else if e.starts_with("Could not reach the agent")
+        || e.contains("JSON-RPC")
+        || e.contains("not a JSON object")
+        || e.contains("valid JSON")
+    {
+        // These already carry a clear, user-facing message — surface verbatim.
+        e.to_string()
+    } else {
+        format!("Couldn't read the agent card: {e}")
+    }
+}
+
+/// Shared core: fetch the card (with 401→token retry inside the transport),
+/// parse it, resolve the JSON-RPC endpoint, and return the parsed card + endpoint.
+async fn fetch_and_resolve<T: A2aTransport>(
+    transport: &T,
+    agent: &AgentDefinition,
+    token: Option<String>,
+) -> Result<(a2a::AgentCard, String), String> {
+    if agent.remote_url.trim().is_empty() {
+        return Err("Enter the agent's URL first.".to_string());
+    }
+    let url = a2a::well_known_card_url(&agent.remote_url);
+    let card_json = transport
+        .fetch_card(url, token)
+        .await
+        .map_err(|e| friendly_card_error(&e))?;
+    let card = a2a::parse_agent_card(&card_json).map_err(|e| friendly_card_error(&e))?;
+    let endpoint = card.select_jsonrpc_endpoint()?;
+    Ok((card, endpoint))
+}
+
+fn find_agent(app: &AppHandle, id: &str) -> Result<AgentDefinition, String> {
+    settings::get_settings(app)
+        .agents
+        .into_iter()
+        .find(|a| a.id == id)
+        .ok_or_else(|| format!("Agent '{id}' not found"))
+}
+
+/// Fetch and resolve a remote agent's card, PERSIST the resolved endpoint +
+/// display metadata onto the agent, and return a summary for the UI. This is the
+/// settings "Fetch card" button.
+#[tauri::command]
+#[specta::specta]
+pub async fn fetch_remote_agent_card(
+    app: AppHandle,
+    agent_id: String,
+) -> Result<AgentCardSummary, String> {
+    let agent = find_agent(&app, &agent_id)?;
+    let token = crate::keychain::get_api_key("agent", &agent_id);
+    let transport = HttpA2aTransport::new();
+
+    let (card, endpoint) = fetch_and_resolve(&transport, &agent, token).await?;
+    let summary = card.summary(endpoint.clone());
+
+    // Persist the resolved endpoint + cached display metadata onto the agent so
+    // a run doesn't have to re-fetch. Re-read to avoid clobbering a concurrent
+    // edit to a different field.
+    let mut current = settings::get_settings(&app);
+    if let Some(a) = current.agents.iter_mut().find(|a| a.id == agent_id) {
+        a.remote_endpoint = endpoint;
+        a.remote_card_name = card.name.clone();
+        a.remote_card_version = card.version.clone();
+        a.remote_streaming = card.streaming;
+        settings::write_settings(&app, current);
+    }
+
+    Ok(summary)
+}
+
+/// Lightweight reachability test: re-fetch the card (with the 401→token retry).
+/// Deliberately does NOT send a real message — that could cost money or trigger
+/// real work on the user's server. Returns the resolved endpoint on success.
+#[tauri::command]
+#[specta::specta]
+pub async fn test_remote_agent(app: AppHandle, agent_id: String) -> Result<String, String> {
+    let agent = find_agent(&app, &agent_id)?;
+    let token = crate::keychain::get_api_key("agent", &agent_id);
+    let transport = HttpA2aTransport::new();
+    let (_card, endpoint) = fetch_and_resolve(&transport, &agent, token).await?;
+    Ok(endpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn friendly_error_maps_401_to_token_hint() {
+        let msg = friendly_card_error("HTTP 401");
+        assert!(msg.contains("token"));
+    }
+
+    #[test]
+    fn friendly_error_maps_404() {
+        assert!(friendly_card_error("HTTP 404").contains("Check the address"));
+    }
+
+    #[test]
+    fn friendly_error_passes_through_no_jsonrpc() {
+        let raw = "This agent doesn't offer a JSON-RPC interface. OpenFlow only speaks the A2A JSON-RPC binding.";
+        assert_eq!(friendly_card_error(raw), raw);
+    }
+
+    #[test]
+    fn friendly_error_passes_through_unreachable() {
+        let raw = "Could not reach the agent: connection refused";
+        assert_eq!(friendly_card_error(raw), raw);
+    }
+
+    #[test]
+    fn friendly_error_wraps_unknown() {
+        assert!(friendly_card_error("weird thing").starts_with("Couldn't read the agent card"));
+    }
+}

--- a/src-tauri/src/commands/service.rs
+++ b/src-tauri/src/commands/service.rs
@@ -1,0 +1,366 @@
+//! OpenFlow Service — pairing / status / connection-test Tauri commands.
+//!
+//! Additive & dormant-by-default: none of this runs until the user pairs a
+//! self-hosted service. The device token lives in the OS keyring (never the
+//! settings store); the URL + opt-in flags live in settings. See the frozen
+//! contract DESIGN-openflow-service.md §5 (API) and §8 (desktop integration).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use tauri::{AppHandle, Manager};
+
+use crate::managers::service_sync::{ServiceSyncManager, KEYRING_ACCOUNT, KEYRING_SCOPE};
+use crate::settings::{get_settings, write_settings};
+
+/// Body POSTed to `/v1/pair`. Pure struct so its construction is unit-testable.
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct PairRequest {
+    pub setup_token: String,
+    pub device_name: String,
+    pub platform: String,
+    pub app_version: String,
+}
+
+/// Construct the pairing request body from the device's own identity. Kept as a
+/// free function (no I/O) so a test can assert the exact wire shape.
+pub fn build_pair_request(
+    setup_token: &str,
+    device_name: &str,
+    platform: &str,
+    app_version: &str,
+) -> PairRequest {
+    PairRequest {
+        setup_token: setup_token.trim().to_string(),
+        device_name: device_name.to_string(),
+        platform: platform.to_string(),
+        app_version: app_version.to_string(),
+    }
+}
+
+/// `201` response from `/v1/pair`.
+#[derive(Deserialize, Debug)]
+struct PairResponse {
+    device_id: String,
+    device_token: String,
+}
+
+/// Returned to the UI after a successful pairing.
+#[derive(Serialize, Debug, Clone, Type)]
+pub struct PairedDeviceInfo {
+    pub device_id: String,
+    pub device_name: String,
+    pub url: String,
+}
+
+/// Status snapshot for the settings UI.
+#[derive(Serialize, Debug, Clone, Type)]
+pub struct ServiceStatus {
+    /// A URL is configured (feature is at least half-set-up).
+    pub configured: bool,
+    /// A device is paired and the integration is active.
+    pub enabled: bool,
+    pub url: String,
+    pub sync_transcripts: bool,
+    pub sync_usage: bool,
+    pub paired_device_name: Option<String>,
+    /// Unix seconds of the last successful push, if any.
+    pub last_sync_at: Option<i64>,
+    /// History rows not yet synced (informational).
+    pub pending_count: Option<i64>,
+}
+
+/// `/v1/info` response.
+#[derive(Deserialize, Debug)]
+struct InfoResponse {
+    version: String,
+    #[serde(default)]
+    edition: String,
+    #[serde(default)]
+    modules: InfoModules,
+    #[serde(default)]
+    #[allow(dead_code)]
+    server_time: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct InfoModules {
+    #[serde(default)]
+    stt: bool,
+    #[serde(default)]
+    llm: bool,
+    #[serde(default)]
+    memory: bool,
+}
+
+/// Typed result of a connection test / info fetch.
+#[derive(Serialize, Debug, Clone, Type)]
+pub struct ServiceInfo {
+    pub version: String,
+    pub edition: String,
+    pub module_stt: bool,
+    pub module_llm: bool,
+    pub module_memory: bool,
+}
+
+fn normalize(base: &str) -> String {
+    base.trim().trim_end_matches('/').to_string()
+}
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap_or_default()
+}
+
+/// Map a non-success pairing status to a friendly, user-facing message.
+fn pair_error_for_status(status: reqwest::StatusCode) -> String {
+    match status.as_u16() {
+        401 | 403 => "Pairing rejected: the setup token is wrong or expired.".to_string(),
+        404 => "No OpenFlow Service found at that URL. Check the address.".to_string(),
+        409 => "This device is already paired with the service.".to_string(),
+        429 => "Too many pairing attempts. Wait a minute and try again.".to_string(),
+        500..=599 => "The service had an internal error. Try again shortly.".to_string(),
+        _ => format!("Pairing failed (HTTP {}).", status.as_u16()),
+    }
+}
+
+/// Pair this device with a self-hosted OpenFlow Service.
+///
+/// On `201`: store the returned `device_token` in the OS keyring, persist the URL,
+/// set `service_enabled = true`, record the device identity, and start the sync
+/// worker. On any error: friendly message, nothing persisted.
+#[tauri::command]
+#[specta::specta]
+pub async fn pair_service(
+    app: AppHandle,
+    url: String,
+    setup_token: String,
+) -> Result<PairedDeviceInfo, String> {
+    let base = normalize(&url);
+    if base.is_empty() {
+        return Err("Enter the service URL.".to_string());
+    }
+    if setup_token.trim().is_empty() {
+        return Err("Enter the setup token from your service.".to_string());
+    }
+
+    let device_name = tauri_plugin_os::hostname();
+    let platform = tauri_plugin_os::platform().to_string();
+    let app_version = app.package_info().version.to_string();
+    let body = build_pair_request(&setup_token, &device_name, &platform, &app_version);
+
+    let resp = http_client()
+        .post(format!("{base}/v1/pair"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Could not reach the service: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(pair_error_for_status(status));
+    }
+
+    let parsed: PairResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("The service returned an unexpected response: {e}"))?;
+
+    // Token → keyring ONLY (never the settings store).
+    crate::keychain::set_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT, &parsed.device_token)
+        .map_err(|e| format!("Could not store the device token securely: {e}"))?;
+
+    // Persist URL + enable; the token is intentionally absent from settings.
+    let mut settings = get_settings(&app);
+    settings.service_url = base.clone();
+    settings.service_enabled = true;
+    write_settings(&app, settings);
+
+    // Record identity + kick the worker (idempotent).
+    let manager = app.state::<Arc<ServiceSyncManager>>();
+    manager.record_pairing(&parsed.device_id, &device_name);
+    manager.ensure_started();
+
+    Ok(PairedDeviceInfo {
+        device_id: parsed.device_id,
+        device_name,
+        url: base,
+    })
+}
+
+/// Unpair: best-effort revoke on the server, then remove the local token and
+/// disable the feature. Always succeeds locally even if the server is unreachable.
+#[tauri::command]
+#[specta::specta]
+pub async fn unpair_service(app: AppHandle) -> Result<(), String> {
+    let settings = get_settings(&app);
+    let base = normalize(&settings.service_url);
+    let token = crate::keychain::get_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT).unwrap_or_default();
+    let device_id = {
+        let manager = app.state::<Arc<ServiceSyncManager>>();
+        manager.snapshot().device_id
+    };
+
+    // Best-effort server-side revoke (DELETE /v1/devices/{self}). Ignore failures.
+    if !base.is_empty() && !token.is_empty() {
+        if let Some(id) = device_id {
+            let _ = http_client()
+                .delete(format!("{base}/v1/devices/{id}"))
+                .bearer_auth(&token)
+                .send()
+                .await;
+        }
+    }
+
+    // Stop the worker, forget the token, clear local state, disable the feature.
+    {
+        let manager = app.state::<Arc<ServiceSyncManager>>();
+        manager.stop();
+        manager.clear_pairing();
+    }
+    let _ = crate::keychain::delete_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT);
+
+    let mut settings = get_settings(&app);
+    settings.service_enabled = false;
+    settings.service_sync_transcripts = false;
+    settings.service_sync_usage = false;
+    // Keep the URL so the field stays pre-filled for a quick re-pair.
+    write_settings(&app, settings);
+
+    Ok(())
+}
+
+/// Current status for the settings UI.
+#[tauri::command]
+#[specta::specta]
+pub fn service_status(app: AppHandle) -> Result<ServiceStatus, String> {
+    let settings = get_settings(&app);
+    let manager = app.state::<Arc<ServiceSyncManager>>();
+    let snap = manager.snapshot();
+    let configured = !settings.service_url.trim().is_empty();
+
+    Ok(ServiceStatus {
+        configured,
+        enabled: settings.service_enabled,
+        url: settings.service_url.clone(),
+        sync_transcripts: settings.service_sync_transcripts,
+        sync_usage: settings.service_sync_usage,
+        paired_device_name: snap.device_name,
+        last_sync_at: snap.last_sync_at,
+        pending_count: if settings.service_enabled {
+            Some(manager.pending_count())
+        } else {
+            None
+        },
+    })
+}
+
+/// Test the connection with the stored token: `GET /v1/info`.
+#[tauri::command]
+#[specta::specta]
+pub async fn test_service_connection(app: AppHandle) -> Result<ServiceInfo, String> {
+    let settings = get_settings(&app);
+    let base = normalize(&settings.service_url);
+    if base.is_empty() {
+        return Err("No service URL configured.".to_string());
+    }
+    let token = crate::keychain::get_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT).unwrap_or_default();
+    if token.is_empty() {
+        return Err("This device is not paired yet.".to_string());
+    }
+
+    let resp = http_client()
+        .get(format!("{base}/v1/info"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|e| format!("Could not reach the service: {e}"))?;
+
+    let status = resp.status();
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        return Err("The service rejected this device's token. Try re-pairing.".to_string());
+    }
+    if !status.is_success() {
+        return Err(format!("The service returned HTTP {}.", status.as_u16()));
+    }
+
+    let info: InfoResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Unexpected response from the service: {e}"))?;
+
+    Ok(ServiceInfo {
+        version: info.version,
+        edition: if info.edition.is_empty() {
+            "community".to_string()
+        } else {
+            info.edition
+        },
+        module_stt: info.modules.stt,
+        module_llm: info.modules.llm,
+        module_memory: info.modules.memory,
+    })
+}
+
+/// Toggle transcript sync (privacy-critical opt-in). Also nudges the worker so a
+/// freshly-enabled sync starts promptly.
+#[tauri::command]
+#[specta::specta]
+pub fn set_service_sync_transcripts(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = get_settings(&app);
+    settings.service_sync_transcripts = enabled;
+    write_settings(&app, settings);
+    app.state::<Arc<ServiceSyncManager>>().ensure_started();
+    Ok(())
+}
+
+/// Toggle usage-event sync (counts/durations only — never text).
+#[tauri::command]
+#[specta::specta]
+pub fn set_service_sync_usage(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let mut settings = get_settings(&app);
+    settings.service_sync_usage = enabled;
+    write_settings(&app, settings);
+    app.state::<Arc<ServiceSyncManager>>().ensure_started();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pair_request_body_is_constructed_verbatim() {
+        let req = build_pair_request("  tok-123  ", "My-Mac", "macos", "0.14.0");
+        // Setup token is trimmed; identity fields pass through untouched.
+        assert_eq!(req.setup_token, "tok-123");
+        assert_eq!(req.device_name, "My-Mac");
+        assert_eq!(req.platform, "macos");
+        assert_eq!(req.app_version, "0.14.0");
+    }
+
+    #[test]
+    fn pair_request_serializes_to_the_contract_shape() {
+        let req = build_pair_request("tok", "host", "windows", "1.2.3");
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["setup_token"], "tok");
+        assert_eq!(json["device_name"], "host");
+        assert_eq!(json["platform"], "windows");
+        assert_eq!(json["app_version"], "1.2.3");
+        // Exactly the four contract fields, nothing extra.
+        assert_eq!(json.as_object().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn pair_error_messages_map_common_statuses() {
+        use reqwest::StatusCode;
+        assert!(pair_error_for_status(StatusCode::UNAUTHORIZED).contains("setup token"));
+        assert!(pair_error_for_status(StatusCode::NOT_FOUND).contains("No OpenFlow Service"));
+        assert!(pair_error_for_status(StatusCode::TOO_MANY_REQUESTS).contains("Too many"));
+        assert!(pair_error_for_status(StatusCode::CONFLICT).contains("already paired"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod a2a;
 mod actions;
 mod active_app;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
@@ -695,6 +696,8 @@ pub fn run(cli_args: CliArgs) {
             commands::agents::update_agent,
             commands::agents::delete_agent,
             commands::agents::test_agent,
+            commands::remote_agents::fetch_remote_agent_card,
+            commands::remote_agents::test_remote_agent,
             commands::ai_modes::create_ai_mode,
             commands::ai_modes::update_ai_mode,
             commands::ai_modes::delete_ai_mode,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -200,6 +200,12 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     // now), and is a sibling of the TranscriptionCoordinator — never a client.
     let meeting_manager = Arc::new(managers::meeting::MeetingManager::new(app_handle));
 
+    // OpenFlow Service sync worker: a dormant-by-default sibling that pushes NEW
+    // history rows (READ-ONLY) + usage events to a user-paired self-hosted service.
+    // Started below ONLY when the feature is configured; never touches dictation.
+    let service_sync_manager =
+        Arc::new(managers::service_sync::ServiceSyncManager::new(app_handle));
+
     // Add managers to Tauri's managed state
     app_handle.manage(recording_manager.clone());
     app_handle.manage(model_manager.clone());
@@ -209,6 +215,7 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     app_handle.manage(wake_word_manager.clone());
     app_handle.manage(agent_run_manager.clone());
     app_handle.manage(meeting_manager.clone());
+    app_handle.manage(service_sync_manager.clone());
 
     // Note: Shortcuts are NOT initialized here.
     // The frontend is responsible for calling the `initialize_shortcuts` command
@@ -348,6 +355,11 @@ fn initialize_core_logic(app_handle: &AppHandle) {
     if settings::get_settings(app_handle).hands_free_enabled {
         wake_word_manager.start();
     }
+
+    // Start the OpenFlow Service sync worker ONLY when the user has paired and the
+    // feature is enabled (byte-for-byte no-op otherwise). `ensure_started` itself
+    // re-checks the gate, so this is safe and idempotent.
+    service_sync_manager.ensure_started();
 
     // Start the meeting detector. Its loop reads settings live and self-suppresses
     // while our own recorder/monitor is active or a meeting capture is running, so
@@ -744,6 +756,12 @@ pub fn run(cli_args: CliArgs) {
             commands::meetings::set_meetings_diarization_provisional,
             commands::meetings::get_diarization_models_status,
             commands::meetings::download_diarization_models,
+            commands::service::pair_service,
+            commands::service::unpair_service,
+            commands::service::service_status,
+            commands::service::test_service_connection,
+            commands::service::set_service_sync_transcripts,
+            commands::service::set_service_sync_usage,
             helpers::clamshell::is_laptop,
         ])
         .events(collect_events![

--- a/src-tauri/src/managers/agent_run.rs
+++ b/src-tauri/src/managers/agent_run.rs
@@ -27,7 +27,8 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
 
-use crate::settings::{AgentCliType, AgentDefinition, AgentOutputSink, PromptDelivery};
+use crate::a2a::{self, A2aTransport, HttpA2aTransport, RemoteOutcome};
+use crate::settings::{AgentCliType, AgentDefinition, AgentKind, AgentOutputSink, PromptDelivery};
 
 /// Cap on the rolling per-run output buffer. Enough to keep a useful tail for
 /// the panel and the written file, bounded so a chatty run can't grow memory
@@ -291,21 +292,36 @@ impl AgentRunManager {
         let binary = agent.binary_path.clone();
         let run_id_task = run_id.clone();
 
-        // Detached task: spawn, stream, finalize. Uses the app's async runtime.
-        tauri::async_runtime::spawn(async move {
-            manager
-                .drive_run(
-                    app,
-                    run_id_task,
-                    agent,
-                    binary,
-                    argv,
-                    cwd,
-                    stdin_input,
-                    kill_rx,
-                )
-                .await;
-        });
+        // Detached task: drive to completion, stream, finalize. Uses the app's
+        // async runtime. The driver seam: a `Remote` (A2A) agent takes the
+        // RemoteDriver; every other kind takes the CLI subprocess driver. The
+        // registry entry, run_id and kill wiring above are identical for both —
+        // the run panel (which only subscribes to the two events) needs nothing.
+        match agent.kind {
+            AgentKind::Remote => {
+                tauri::async_runtime::spawn(async move {
+                    manager
+                        .drive_remote_run(app, run_id_task, agent, instruction, kill_rx)
+                        .await;
+                });
+            }
+            _ => {
+                tauri::async_runtime::spawn(async move {
+                    manager
+                        .drive_run(
+                            app,
+                            run_id_task,
+                            agent,
+                            binary,
+                            argv,
+                            cwd,
+                            stdin_input,
+                            kill_rx,
+                        )
+                        .await;
+                });
+            }
+        }
 
         run_id
     }
@@ -448,6 +464,131 @@ impl AgentRunManager {
         }
 
         self.finalize(&app, &run_id, &agent, status, started).await;
+    }
+
+    /// Drive a **remote (A2A) agent** run behind the SAME run seam as
+    /// `drive_run`: it reuses `append_output` / the `AgentRunOutput` event /
+    /// `finalize` / the kill channel / `AgentRunStatus` verbatim, so the run
+    /// panel needs zero changes. The protocol itself lives in `crate::a2a`
+    /// (`run_remote_protocol`), which is unit-tested against a mock transport
+    /// with no network — this method is the thin glue (endpoint resolution,
+    /// header line, live-output plumbing, status mapping).
+    async fn drive_remote_run(
+        self: Arc<Self>,
+        app: AppHandle,
+        run_id: String,
+        agent: AgentDefinition,
+        instruction: String,
+        mut kill_rx: mpsc::UnboundedReceiver<()>,
+    ) {
+        let started = std::time::Instant::now();
+        let transport = HttpA2aTransport::new();
+        // Per-agent bearer token from the OS keyring (scope "agent", account =
+        // agent id). Never in the settings store; absent for a public agent.
+        let token = crate::keychain::get_api_key("agent", &agent.id);
+
+        // 1. Resolve the JSON-RPC endpoint. Cached on the agent after a UI card
+        //    fetch; if empty we attempt one fetch+resolve here, and a failure is
+        //    an actionable Failed (raw English in the stream, like CLI output).
+        let endpoint = match self
+            .resolve_remote_endpoint(&transport, &agent, token.clone())
+            .await
+        {
+            Ok(ep) => ep,
+            Err(e) => {
+                self.emit_line(&app, &run_id, &e);
+                self.finalize(
+                    &app,
+                    &run_id,
+                    &agent,
+                    RunStatus::Failed { error: e },
+                    started,
+                )
+                .await;
+                return;
+            }
+        };
+
+        // 2. Header line so the panel shows where this is going.
+        let name = if agent.remote_card_name.trim().is_empty() {
+            agent.remote_url.clone()
+        } else {
+            agent.remote_card_name.clone()
+        };
+        self.emit_line(&app, &run_id, &format!("→ {name} @ {endpoint}"));
+
+        // 3. Run the protocol, streaming each new text chunk live into the panel.
+        let manager = Arc::clone(&self);
+        let app_out = app.clone();
+        let run_id_out = run_id.clone();
+        let mut on_output = move |chunk: &str| {
+            manager.append_output(&run_id_out, chunk);
+            let _ = AgentRunOutput {
+                run_id: run_id_out.clone(),
+                chunk: chunk.to_string(),
+            }
+            .emit(&app_out);
+        };
+
+        let outcome = a2a::run_remote_protocol(
+            &transport,
+            &endpoint,
+            token,
+            &instruction,
+            agent.remote_streaming,
+            &mut kill_rx,
+            &mut on_output,
+            a2a::POLL_INTERVAL,
+            a2a::POLL_CAP,
+        )
+        .await;
+        drop(on_output);
+
+        let status = match outcome {
+            RemoteOutcome::Finished => RunStatus::Finished { code: 0 },
+            RemoteOutcome::Failed(error) => RunStatus::Failed { error },
+            RemoteOutcome::Stopped => RunStatus::Stopped,
+        };
+        self.finalize(&app, &run_id, &agent, status, started).await;
+    }
+
+    /// Resolve a remote agent's JSON-RPC endpoint: the cached `remote_endpoint`
+    /// when present, otherwise one card fetch+resolve (with an actionable error
+    /// pointing the user at the settings "Fetch card" button).
+    async fn resolve_remote_endpoint<T: A2aTransport>(
+        &self,
+        transport: &T,
+        agent: &AgentDefinition,
+        token: Option<String>,
+    ) -> Result<String, String> {
+        if !agent.remote_endpoint.trim().is_empty() {
+            return Ok(agent.remote_endpoint.clone());
+        }
+        if agent.remote_url.trim().is_empty() {
+            return Err(
+                "This remote agent has no URL. Open its settings, enter the \
+                        agent URL, and Fetch the card first."
+                    .to_string(),
+            );
+        }
+        let url = a2a::well_known_card_url(&agent.remote_url);
+        let card_json = transport.fetch_card(url, token).await.map_err(|e| {
+            format!("Couldn't fetch the agent card ({e}). Fetch the agent card in settings first.")
+        })?;
+        let card = a2a::parse_agent_card(&card_json)?;
+        card.select_jsonrpc_endpoint()
+    }
+
+    /// Append a plain line to the run buffer AND emit it as an `agent-run-output`
+    /// event (the header line and remote-driver error lines flow through here —
+    /// like CLI subprocess output, the remote stream is raw, un-i18n'd text).
+    fn emit_line(&self, app: &AppHandle, run_id: &str, line: &str) {
+        self.append_output(run_id, line);
+        let _ = AgentRunOutput {
+            run_id: run_id.to_string(),
+            chunk: line.to_string(),
+        }
+        .emit(app);
     }
 
     /// Set the terminal status, emit `agent-run-status`, and run the output sinks.

--- a/src-tauri/src/managers/mod.rs
+++ b/src-tauri/src/managers/mod.rs
@@ -6,5 +6,6 @@ pub mod history;
 pub mod meeting;
 pub mod model;
 pub mod model_capabilities;
+pub mod service_sync;
 pub mod transcription;
 pub mod wake_word;

--- a/src-tauri/src/managers/service_sync.rs
+++ b/src-tauri/src/managers/service_sync.rs
@@ -1,0 +1,721 @@
+//! OpenFlow Service — dictation transcript + usage sync worker.
+//!
+//! This is a *sibling* pipeline, never part of the core dictation path (hotkey →
+//! capture → STT → cleanup → inject). It runs a single background tokio task that,
+//! every 30s, reads NEW rows from the existing history SQLite (`history.db`,
+//! READ-ONLY — the schema is never modified) and pushes them to a user-paired,
+//! self-hosted OpenFlow Service per the frozen contract (DESIGN-openflow-service.md
+//! §5/§8). It is fully dormant unless the user has paired and opted in:
+//!
+//!   * The task is only ever started when `service_enabled && !service_url.empty`.
+//!   * Transcript TEXT is pushed ONLY when `service_sync_transcripts` is true — the
+//!     hard privacy rule. Usage events (`service_sync_usage`) carry counts/durations
+//!     only, never text.
+//!   * Its cursor + device identity live in a SEPARATE `service_sync.db`, so the
+//!     history database and the dictation loop are untouched.
+//!
+//! The HTTP calls sit behind the [`ServiceTransport`] trait so the batching /
+//! backoff / payload logic is unit-testable with no network.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::DateTime;
+use log::{debug, warn};
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+use tauri::AppHandle;
+
+/// Keyring scope/account the device token is stored under. Mirrors the existing
+/// `keychain` pattern used for provider API keys — the token NEVER touches the
+/// settings store on disk.
+pub const KEYRING_SCOPE: &str = "service";
+pub const KEYRING_ACCOUNT: &str = "device_token";
+
+/// Max items per push batch (contract §8: batches ≤ 50).
+pub const MAX_BATCH: usize = 50;
+
+/// Backoff floor / ceiling on repeated push failure (contract §8: 30s → 5min cap).
+pub const BACKOFF_MIN: Duration = Duration::from_secs(30);
+pub const BACKOFF_MAX: Duration = Duration::from_secs(300);
+
+/// Normal poll cadence between sync passes.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Pure data + logic (unit-tested; no I/O)
+// ---------------------------------------------------------------------------
+
+/// A minimal, read-only view of one `transcription_history` row that the sync
+/// worker cares about. Deliberately decoupled from `HistoryEntry` so this module
+/// never depends on the history manager's write path.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SyncRow {
+    /// The history SQLite rowid. Stable and monotonic → used verbatim as the
+    /// idempotency `client_id`, so re-sending a row is a server-side no-op.
+    pub rowid: i64,
+    /// Unix seconds (the history `timestamp` column).
+    pub created_at: i64,
+    /// The transcript text (STT output).
+    pub text: String,
+    /// Duration in milliseconds, if the source row carries one. The
+    /// `transcription_history` table does not have a duration column today, so
+    /// this is `None` in practice — the plumbing honors the contract's
+    /// `value=duration_ms` for the day a duration becomes available.
+    pub duration_ms: Option<i64>,
+}
+
+/// Stable idempotency key for a row: the history rowid as a string. Identical for
+/// the transcript push and the paired usage event, so the service can dedupe both
+/// on `(device_id, client_id)`.
+pub fn client_id_for(rowid: i64) -> String {
+    rowid.to_string()
+}
+
+/// Split rows into ordered batches of at most [`MAX_BATCH`], preserving order.
+pub fn into_batches(rows: &[SyncRow]) -> Vec<Vec<SyncRow>> {
+    rows.chunks(MAX_BATCH).map(|c| c.to_vec()).collect()
+}
+
+/// Next backoff after a failure: double the current delay, clamped to
+/// [`BACKOFF_MIN`, `BACKOFF_MAX`]. A zero/sub-floor input starts at the floor.
+pub fn next_backoff(current: Duration) -> Duration {
+    if current < BACKOFF_MIN {
+        return BACKOFF_MIN;
+    }
+    let doubled = current.saturating_mul(2);
+    if doubled > BACKOFF_MAX {
+        BACKOFF_MAX
+    } else {
+        doubled
+    }
+}
+
+/// RFC3339 UTC rendering of a unix-seconds timestamp (contract: all timestamps
+/// RFC3339 UTC). Falls back to the epoch for an out-of-range value rather than
+/// ever panicking on the sync path.
+pub fn to_rfc3339(unix_secs: i64) -> String {
+    DateTime::from_timestamp(unix_secs, 0)
+        .unwrap_or_else(|| DateTime::from_timestamp(0, 0).expect("epoch is valid"))
+        .to_rfc3339()
+}
+
+// ---- wire payloads (contract §5) ----
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct TranscriptItem {
+    pub client_id: String,
+    pub created_at: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<i64>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct TranscriptsBody {
+    pub items: Vec<TranscriptItem>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct UsageItem {
+    pub client_id: String,
+    pub kind: String,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<i64>,
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq)]
+pub struct UsageBody {
+    pub items: Vec<UsageItem>,
+}
+
+/// Build the `/v1/transcripts` body for a batch (carries TEXT — only ever called
+/// when `service_sync_transcripts` is on).
+pub fn build_transcripts_body(rows: &[SyncRow]) -> TranscriptsBody {
+    TranscriptsBody {
+        items: rows
+            .iter()
+            .map(|r| TranscriptItem {
+                client_id: client_id_for(r.rowid),
+                created_at: to_rfc3339(r.created_at),
+                text: r.text.clone(),
+                duration_ms: r.duration_ms,
+            })
+            .collect(),
+    }
+}
+
+/// Build the `/v1/usage` body for a batch. Contains NO transcript text — only the
+/// stable client_id, kind, timestamp and (optional) duration value.
+pub fn build_usage_body(rows: &[SyncRow]) -> UsageBody {
+    UsageBody {
+        items: rows
+            .iter()
+            .map(|r| UsageItem {
+                client_id: client_id_for(r.rowid),
+                kind: "dictation".to_string(),
+                created_at: to_rfc3339(r.created_at),
+                value: r.duration_ms,
+            })
+            .collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP transport abstraction
+// ---------------------------------------------------------------------------
+
+/// The two write calls the worker makes, behind a trait so logic can be tested
+/// without a network. Owned args keep the returned futures `'static` + `Send`.
+pub trait ServiceTransport: Send + Sync + 'static {
+    fn post_transcripts(
+        &self,
+        base_url: String,
+        token: String,
+        body: TranscriptsBody,
+    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
+
+    fn post_usage(
+        &self,
+        base_url: String,
+        token: String,
+        body: UsageBody,
+    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
+}
+
+/// Production transport backed by `reqwest`. Normalizes the base URL and maps
+/// non-2xx / transport errors to a short string (logged, then retried).
+pub struct HttpTransport {
+    client: reqwest::Client,
+}
+
+impl Default for HttpTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpTransport {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_default();
+        Self { client }
+    }
+
+    async fn post_json<B: Serialize>(
+        &self,
+        base_url: &str,
+        token: &str,
+        path: &str,
+        body: &B,
+    ) -> Result<(), String> {
+        let url = format!("{}{}", normalize_base_url(base_url), path);
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| format!("request failed: {e}"))?;
+        let status = resp.status();
+        if status.is_success() {
+            Ok(())
+        } else {
+            let text = resp.text().await.unwrap_or_default();
+            Err(format!(
+                "HTTP {status}: {}",
+                text.chars().take(200).collect::<String>()
+            ))
+        }
+    }
+}
+
+impl ServiceTransport for HttpTransport {
+    async fn post_transcripts(
+        &self,
+        base_url: String,
+        token: String,
+        body: TranscriptsBody,
+    ) -> Result<(), String> {
+        self.post_json(&base_url, &token, "/v1/transcripts", &body)
+            .await
+    }
+
+    async fn post_usage(
+        &self,
+        base_url: String,
+        token: String,
+        body: UsageBody,
+    ) -> Result<(), String> {
+        self.post_json(&base_url, &token, "/v1/usage", &body).await
+    }
+}
+
+/// Strip a trailing slash so `format!("{base}/v1/...")` never doubles up.
+pub fn normalize_base_url(base: &str) -> String {
+    base.trim().trim_end_matches('/').to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Sync-state persistence (its OWN db — history.db is never written)
+// ---------------------------------------------------------------------------
+
+fn open_state_db(path: &PathBuf) -> rusqlite::Result<Connection> {
+    let conn = Connection::open(path)?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sync_state (
+            key   TEXT PRIMARY KEY,
+            value TEXT
+        )",
+        [],
+    )?;
+    Ok(conn)
+}
+
+fn state_get(conn: &Connection, key: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT value FROM sync_state WHERE key = ?1",
+        [key],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
+fn state_set(conn: &Connection, key: &str, value: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO sync_state (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        [key, value],
+    )?;
+    Ok(())
+}
+
+const KEY_CURSOR: &str = "cursor";
+const KEY_LAST_SYNC_AT: &str = "last_sync_at";
+const KEY_DEVICE_ID: &str = "device_id";
+const KEY_DEVICE_NAME: &str = "device_name";
+
+/// A snapshot of sync progress for the status command.
+#[derive(Clone, Debug, Default)]
+pub struct SyncStateSnapshot {
+    pub device_id: Option<String>,
+    pub device_name: Option<String>,
+    pub last_sync_at: Option<i64>,
+    pub cursor: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+/// Owns the sync-state db path and the running flag. Managed in Tauri state; the
+/// worker task is (re)started idempotently via [`Self::ensure_started`].
+pub struct ServiceSyncManager {
+    app: AppHandle,
+    state_db_path: PathBuf,
+    history_db_path: PathBuf,
+    running: Arc<AtomicBool>,
+}
+
+impl ServiceSyncManager {
+    pub fn new(app: &AppHandle) -> Self {
+        // Best-effort resolve of the data dir; if it fails we fall back to a
+        // relative path (the worker will simply log and never start syncing).
+        let data_dir = crate::portable::app_data_dir(app).unwrap_or_else(|_| PathBuf::from("."));
+        Self {
+            app: app.clone(),
+            state_db_path: data_dir.join("service_sync.db"),
+            history_db_path: data_dir.join("history.db"),
+            running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Persist the device identity after a successful pairing (used by the status
+    /// UI). The token itself goes to the keyring, never here.
+    pub fn record_pairing(&self, device_id: &str, device_name: &str) {
+        if let Ok(conn) = open_state_db(&self.state_db_path) {
+            let _ = state_set(&conn, KEY_DEVICE_ID, device_id);
+            let _ = state_set(&conn, KEY_DEVICE_NAME, device_name);
+        }
+    }
+
+    /// Forget the paired device identity + cursor on unpair. Leaves the table so a
+    /// later re-pair starts clean.
+    pub fn clear_pairing(&self) {
+        if let Ok(conn) = open_state_db(&self.state_db_path) {
+            let _ = conn.execute("DELETE FROM sync_state", []);
+        }
+    }
+
+    /// Read a snapshot of sync progress (for `service_status`).
+    pub fn snapshot(&self) -> SyncStateSnapshot {
+        let mut snap = SyncStateSnapshot::default();
+        if let Ok(conn) = open_state_db(&self.state_db_path) {
+            snap.device_id = state_get(&conn, KEY_DEVICE_ID);
+            snap.device_name = state_get(&conn, KEY_DEVICE_NAME);
+            snap.last_sync_at = state_get(&conn, KEY_LAST_SYNC_AT).and_then(|v| v.parse().ok());
+            snap.cursor = state_get(&conn, KEY_CURSOR)
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0);
+        }
+        snap
+    }
+
+    /// Count history rows not yet synced (id > cursor). Read-only; returns 0 on
+    /// any error so the status UI degrades gracefully.
+    pub fn pending_count(&self) -> i64 {
+        let cursor = self.snapshot().cursor;
+        read_pending_count(&self.history_db_path, cursor).unwrap_or(0)
+    }
+
+    /// Stop the worker (unpair / disable). The loop observes the flag each pass.
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+    }
+
+    /// Start the worker if it is not already running AND the feature is
+    /// configured. Idempotent — safe to call from setup, after pairing, and on
+    /// settings changes.
+    pub fn ensure_started(&self) {
+        let settings = crate::settings::get_settings(&self.app);
+        if !settings.service_enabled || settings.service_url.trim().is_empty() {
+            return;
+        }
+        // CAS false→true so only one loop ever runs.
+        if self
+            .running
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let app = self.app.clone();
+        let state_db_path = self.state_db_path.clone();
+        let history_db_path = self.history_db_path.clone();
+        let running = self.running.clone();
+        let transport = Arc::new(HttpTransport::new());
+
+        tauri::async_runtime::spawn(async move {
+            run_sync_loop(app, transport, state_db_path, history_db_path, running).await;
+        });
+    }
+}
+
+/// The background loop. Generic over the transport so tests can drive it without a
+/// network (the app only ever instantiates it with [`HttpTransport`]).
+async fn run_sync_loop<T: ServiceTransport>(
+    app: AppHandle,
+    transport: Arc<T>,
+    state_db_path: PathBuf,
+    history_db_path: PathBuf,
+    running: Arc<AtomicBool>,
+) {
+    debug!("service_sync: worker started");
+    let mut backoff: Option<Duration> = None;
+
+    while running.load(Ordering::SeqCst) {
+        let settings = crate::settings::get_settings(&app);
+
+        // Feature turned off underneath us (unpair) → exit cleanly.
+        if !settings.service_enabled || settings.service_url.trim().is_empty() {
+            debug!("service_sync: feature disabled, worker exiting");
+            break;
+        }
+
+        // Nothing to do unless at least one sync type is opted in. Sit idle.
+        let want_transcripts = settings.service_sync_transcripts;
+        let want_usage = settings.service_sync_usage;
+        if !want_transcripts && !want_usage {
+            sleep_interruptible(POLL_INTERVAL, &running).await;
+            continue;
+        }
+
+        let token = match crate::keychain::get_api_key(KEYRING_SCOPE, KEYRING_ACCOUNT) {
+            Some(t) if !t.is_empty() => t,
+            _ => {
+                // Paired flag set but no token (shouldn't happen) — back off.
+                warn!("service_sync: enabled but no device token in keyring");
+                sleep_interruptible(POLL_INTERVAL, &running).await;
+                continue;
+            }
+        };
+
+        match sync_once(
+            transport.as_ref(),
+            &settings.service_url,
+            &token,
+            &state_db_path,
+            &history_db_path,
+            want_transcripts,
+            want_usage,
+        )
+        .await
+        {
+            Ok(pushed) => {
+                if pushed > 0 {
+                    debug!("service_sync: pushed {pushed} row(s)");
+                }
+                backoff = None;
+                sleep_interruptible(POLL_INTERVAL, &running).await;
+            }
+            Err(e) => {
+                let delay = next_backoff(backoff.unwrap_or(Duration::ZERO));
+                backoff = Some(delay);
+                warn!(
+                    "service_sync: push failed ({e}); retrying in {}s",
+                    delay.as_secs()
+                );
+                sleep_interruptible(delay, &running).await;
+            }
+        }
+    }
+
+    running.store(false, Ordering::SeqCst);
+    debug!("service_sync: worker stopped");
+}
+
+/// One sync pass: read rows past the cursor, push in batches, advance the cursor
+/// only on success. Returns the number of rows pushed. Never touches history.db
+/// except to READ.
+async fn sync_once<T: ServiceTransport>(
+    transport: &T,
+    base_url: &str,
+    token: &str,
+    state_db_path: &PathBuf,
+    history_db_path: &PathBuf,
+    want_transcripts: bool,
+    want_usage: bool,
+) -> Result<usize, String> {
+    let cursor = {
+        let conn = open_state_db(state_db_path).map_err(|e| format!("state db: {e}"))?;
+        state_get(&conn, KEY_CURSOR)
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(0)
+    };
+
+    let rows = read_history_since(history_db_path, cursor, 500)
+        .map_err(|e| format!("history read: {e}"))?;
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let mut pushed = 0usize;
+    for batch in into_batches(&rows) {
+        if batch.is_empty() {
+            continue;
+        }
+        // Privacy rule: transcript TEXT is only ever sent when opted in.
+        if want_transcripts {
+            transport
+                .post_transcripts(
+                    base_url.to_string(),
+                    token.to_string(),
+                    build_transcripts_body(&batch),
+                )
+                .await?;
+        }
+        if want_usage {
+            transport
+                .post_usage(
+                    base_url.to_string(),
+                    token.to_string(),
+                    build_usage_body(&batch),
+                )
+                .await?;
+        }
+
+        // Advance the cursor to the last row of this batch and stamp the sync
+        // time. Only reached when the required post(s) above succeeded.
+        let last_rowid = batch.last().map(|r| r.rowid).unwrap_or(cursor);
+        let conn = open_state_db(state_db_path).map_err(|e| format!("state db: {e}"))?;
+        state_set(&conn, KEY_CURSOR, &last_rowid.to_string())
+            .map_err(|e| format!("cursor persist: {e}"))?;
+        state_set(
+            &conn,
+            KEY_LAST_SYNC_AT,
+            &chrono::Utc::now().timestamp().to_string(),
+        )
+        .map_err(|e| format!("last_sync persist: {e}"))?;
+        pushed += batch.len();
+    }
+
+    Ok(pushed)
+}
+
+/// READ-ONLY query of the existing history db for rows past the cursor.
+fn read_history_since(
+    history_db_path: &PathBuf,
+    cursor: i64,
+    limit: i64,
+) -> rusqlite::Result<Vec<SyncRow>> {
+    let conn = Connection::open_with_flags(
+        history_db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let mut stmt = conn.prepare(
+        "SELECT id, timestamp, transcription_text
+         FROM transcription_history
+         WHERE id > ?1
+         ORDER BY id ASC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(rusqlite::params![cursor, limit], |row| {
+            Ok(SyncRow {
+                rowid: row.get(0)?,
+                created_at: row.get(1)?,
+                text: row.get(2)?,
+                duration_ms: None,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// READ-ONLY count of history rows past the cursor (for status pending_count).
+fn read_pending_count(history_db_path: &PathBuf, cursor: i64) -> rusqlite::Result<i64> {
+    let conn = Connection::open_with_flags(
+        history_db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    conn.query_row(
+        "SELECT COUNT(*) FROM transcription_history WHERE id > ?1",
+        [cursor],
+        |row| row.get(0),
+    )
+}
+
+/// Sleep up to `dur`, waking early (in ~1s slices) if `running` is cleared, so an
+/// unpair takes effect promptly rather than after a full poll interval.
+async fn sleep_interruptible(dur: Duration, running: &Arc<AtomicBool>) {
+    let mut remaining = dur;
+    let step = Duration::from_secs(1);
+    while remaining > Duration::ZERO {
+        if !running.load(Ordering::SeqCst) {
+            return;
+        }
+        let this = remaining.min(step);
+        tokio::time::sleep(this).await;
+        remaining = remaining.saturating_sub(this);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(rowid: i64) -> SyncRow {
+        SyncRow {
+            rowid,
+            created_at: 1_600_000_000 + rowid,
+            text: format!("row {rowid}"),
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn batching_splits_into_chunks_of_50() {
+        let rows: Vec<SyncRow> = (1..=125).map(row).collect();
+        let batches = into_batches(&rows);
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[0].len(), 50);
+        assert_eq!(batches[1].len(), 50);
+        assert_eq!(batches[2].len(), 25);
+        // Order is preserved end to end.
+        assert_eq!(batches[0][0].rowid, 1);
+        assert_eq!(batches[2][24].rowid, 125);
+    }
+
+    #[test]
+    fn batching_handles_empty_and_exact_boundary() {
+        assert!(into_batches(&[]).is_empty());
+        let exact: Vec<SyncRow> = (1..=50).map(row).collect();
+        let b = into_batches(&exact);
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].len(), 50);
+        let plus_one: Vec<SyncRow> = (1..=51).map(row).collect();
+        let b2 = into_batches(&plus_one);
+        assert_eq!(b2.len(), 2);
+        assert_eq!(b2[1].len(), 1);
+    }
+
+    #[test]
+    fn client_id_is_the_rowid_and_stable() {
+        assert_eq!(client_id_for(42), "42");
+        // Same row → same client_id every time (idempotency guarantee).
+        assert_eq!(client_id_for(42), client_id_for(42));
+        // The transcript push and the usage push for a row share the client_id.
+        let r = row(7);
+        let t = build_transcripts_body(std::slice::from_ref(&r));
+        let u = build_usage_body(std::slice::from_ref(&r));
+        assert_eq!(t.items[0].client_id, "7");
+        assert_eq!(u.items[0].client_id, "7");
+        assert_eq!(t.items[0].client_id, u.items[0].client_id);
+    }
+
+    #[test]
+    fn backoff_progression_doubles_and_caps() {
+        // Starts at the 30s floor from zero.
+        let d0 = next_backoff(Duration::ZERO);
+        assert_eq!(d0, BACKOFF_MIN);
+        // Doubles: 30 → 60 → 120 → 240 → 300 (cap), then stays at 300.
+        let d1 = next_backoff(d0);
+        assert_eq!(d1, Duration::from_secs(60));
+        let d2 = next_backoff(d1);
+        assert_eq!(d2, Duration::from_secs(120));
+        let d3 = next_backoff(d2);
+        assert_eq!(d3, Duration::from_secs(240));
+        let d4 = next_backoff(d3);
+        assert_eq!(d4, BACKOFF_MAX); // capped at 300
+        let d5 = next_backoff(d4);
+        assert_eq!(d5, BACKOFF_MAX); // stays capped
+    }
+
+    #[test]
+    fn usage_body_never_contains_text() {
+        let rows: Vec<SyncRow> = (1..=3).map(row).collect();
+        let usage = build_usage_body(&rows);
+        let json = serde_json::to_string(&usage).unwrap();
+        // The transcript text ("row 1" etc.) must NOT appear in a usage payload.
+        assert!(!json.contains("row 1"));
+        assert!(json.contains("\"kind\":\"dictation\""));
+        assert_eq!(usage.items.len(), 3);
+    }
+
+    #[test]
+    fn transcript_body_carries_text_and_rfc3339_timestamp() {
+        let r = SyncRow {
+            rowid: 5,
+            created_at: 1_600_000_000,
+            text: "hello world".to_string(),
+            duration_ms: Some(4200),
+        };
+        let body = build_transcripts_body(std::slice::from_ref(&r));
+        assert_eq!(body.items[0].text, "hello world");
+        assert_eq!(body.items[0].client_id, "5");
+        assert_eq!(body.items[0].duration_ms, Some(4200));
+        // RFC3339 UTC (2020-09-13T12:26:40+00:00).
+        assert!(body.items[0].created_at.starts_with("2020-09-13T12:26:40"));
+    }
+
+    #[test]
+    fn duration_is_omitted_from_json_when_absent() {
+        let body = build_transcripts_body(std::slice::from_ref(&row(1)));
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(!json.contains("duration_ms"));
+    }
+
+    #[test]
+    fn normalize_base_url_strips_trailing_slash() {
+        assert_eq!(normalize_base_url("https://x.io/"), "https://x.io");
+        assert_eq!(normalize_base_url("https://x.io"), "https://x.io");
+        assert_eq!(normalize_base_url("  https://x.io/  "), "https://x.io");
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -112,13 +112,17 @@ impl Default for AgentOutputMode {
 /// Flow OS increment 2 — what KIND of agent this is. `Prompt` is the increment-1
 /// behavior (dictation routed through a persona LLM before injection). `Cli`
 /// drives a REAL local coding-agent binary (Claude Code, Codex, …) as a
-/// subprocess in a chosen project folder. Defaults to `Prompt` so every agent
-/// stored before this field existed stays a prompt agent, byte-for-byte.
+/// subprocess in a chosen project folder. `Remote` (increment 3) drives a
+/// spec-compliant **A2A** server the user points OpenFlow at (their VPS agent, a
+/// hosted flow, any endpoint) over the A2A JSON-RPC binding. Defaults to
+/// `Prompt` so every agent stored before this field existed stays a prompt
+/// agent, byte-for-byte.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentKind {
     Prompt,
     Cli,
+    Remote,
 }
 
 impl Default for AgentKind {
@@ -332,6 +336,26 @@ pub struct AgentDefinition {
     /// How the instruction reaches the CLI. `Stdin` (default) or `Arg`.
     #[serde(default)]
     pub prompt_via: PromptDelivery,
+
+    // ---- Flow OS increment 3: Remote agents (A2A) ----
+    /// The A2A agent's base URL as entered by the user. We derive
+    /// `<origin>/.well-known/agent-card.json`; a full `…/agent-card.json` URL is
+    /// accepted verbatim. Only meaningful when `kind == Remote`.
+    #[serde(default)]
+    pub remote_url: String,
+    /// The resolved JSON-RPC endpoint URL from the agent card, cached at fetch
+    /// time. Empty until the first successful `fetch_remote_agent_card`.
+    #[serde(default)]
+    pub remote_endpoint: String,
+    /// Display name cached from the agent card.
+    #[serde(default)]
+    pub remote_card_name: String,
+    /// Version cached from the agent card.
+    #[serde(default)]
+    pub remote_card_version: String,
+    /// Card `capabilities.streaming`, cached — whether we may use `message/stream`.
+    #[serde(default)]
+    pub remote_streaming: bool,
 }
 
 /// What an AI Mode does with the raw transcript before it reaches the cursor.
@@ -2285,6 +2309,44 @@ mod tests {
         assert!(agent.project_path.is_empty());
         assert_eq!(agent.output_sinks, vec![AgentOutputSink::Panel]);
         assert_eq!(agent.prompt_via, PromptDelivery::Stdin);
+        // Increment-3 remote fields must also default to empty/false so a
+        // pre-remote store stays byte-for-byte a Prompt agent.
+        assert!(agent.remote_url.is_empty());
+        assert!(agent.remote_endpoint.is_empty());
+        assert!(agent.remote_card_name.is_empty());
+        assert!(agent.remote_card_version.is_empty());
+        assert!(!agent.remote_streaming);
+    }
+
+    #[test]
+    fn remote_agent_round_trips_through_serde() {
+        // A remote (A2A) agent's new fields must survive a serialize→deserialize
+        // cycle (this is what create_agent/update_agent persist through), and a
+        // `kind:"remote"` value must map to AgentKind::Remote.
+        let raw = serde_json::json!({
+            "id": "vps",
+            "name": "My VPS Agent",
+            "enabled": true,
+            "binding_id": "agent:vps",
+            "provider_id": "",
+            "kind": "remote",
+            "remote_url": "https://agent.example.com",
+            "remote_endpoint": "https://agent.example.com/a2a/v1",
+            "remote_card_name": "Example Agent",
+            "remote_card_version": "1.2.3",
+            "remote_streaming": true,
+            "output_mode": "inject"
+        });
+        let agent: AgentDefinition = serde_json::from_value(raw).unwrap();
+        assert_eq!(agent.kind, AgentKind::Remote);
+        assert_eq!(agent.remote_url, "https://agent.example.com");
+        assert_eq!(agent.remote_endpoint, "https://agent.example.com/a2a/v1");
+        assert_eq!(agent.remote_card_name, "Example Agent");
+        assert_eq!(agent.remote_card_version, "1.2.3");
+        assert!(agent.remote_streaming);
+        // CLI fields stay at their defaults for a remote agent.
+        assert!(agent.cli_type.is_none());
+        assert!(agent.binary_path.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -981,6 +981,30 @@ pub struct AppSettings {
     /// (DESIGN-meetings.md §5.4 auto-degrade). Users on fast machines can opt in.
     #[serde(default)]
     pub meetings_diarization_provisional: bool,
+
+    // ---- OpenFlow Service ("Connect to my service") ----
+    /// Base URL of the paired self-hosted OpenFlow Service (e.g.
+    /// `https://openflow.example.com`). Empty = feature fully dormant: no sync
+    /// worker is ever started and nothing leaves the machine. The device token
+    /// itself is NEVER stored here — it lives in the OS keyring (scope
+    /// `"service"`, account `"device_token"`); this struct only holds the URL and
+    /// opt-in flags. All four fields are `#[serde(default)]` so an old settings
+    /// store (with none of these keys) deserializes byte-for-byte as before.
+    #[serde(default)]
+    pub service_url: String,
+    /// Whether a device is paired and the integration is active. Set true only on
+    /// a successful `pair_service`; cleared by `unpair_service`. When false the
+    /// sync worker does nothing even if a URL is present.
+    #[serde(default)]
+    pub service_enabled: bool,
+    /// Opt-in: push dictation transcript TEXT to the service. Default OFF. When
+    /// false, transcript text NEVER leaves the machine (privacy rule).
+    #[serde(default)]
+    pub service_sync_transcripts: bool,
+    /// Opt-in: push usage events (dictation counts/durations, NO text) to the
+    /// service. Default OFF. Independent of `service_sync_transcripts`.
+    #[serde(default)]
+    pub service_sync_usage: bool,
 }
 
 fn default_meeting_app_allowlist() -> Vec<String> {
@@ -1564,6 +1588,12 @@ pub fn get_default_settings() -> AppSettings {
         meeting_app_allowlist: default_meeting_app_allowlist(),
         meetings_diarization: true,
         meetings_diarization_provisional: false,
+
+        // OpenFlow Service — dormant by default (empty URL, all opt-ins off).
+        service_url: String::new(),
+        service_enabled: false,
+        service_sync_transcripts: false,
+        service_sync_usage: false,
     }
 }
 
@@ -1925,6 +1955,33 @@ mod tests {
         assert_eq!(fresh.default_ai_mode_id, None);
         assert!(!fresh.basic_filler_filter);
         assert!(fresh.hotkey_overlay_enabled);
+    }
+
+    #[test]
+    fn legacy_store_without_service_fields_defaults_them_off() {
+        // Non-breaking proof for the OpenFlow Service feature: a settings store
+        // persisted BEFORE any `service_*` key existed must deserialize with the
+        // integration fully dormant — empty URL, everything off — so an upgrading
+        // user's config is byte-for-byte unaffected and nothing is ever synced
+        // until they explicitly pair and opt in.
+        let raw = serde_json::json!({
+            "bindings": {},
+            "push_to_talk": true,
+            "audio_feedback": false
+        });
+        let settings: AppSettings =
+            serde_json::from_value(raw).expect("pre-service store should deserialize");
+        assert_eq!(settings.service_url, "");
+        assert!(!settings.service_enabled);
+        assert!(!settings.service_sync_transcripts);
+        assert!(!settings.service_sync_usage);
+
+        // Fresh-install defaults match: the feature is dormant out of the box.
+        let fresh = get_default_settings();
+        assert_eq!(fresh.service_url, "");
+        assert!(!fresh.service_enabled);
+        assert!(!fresh.service_sync_transcripts);
+        assert!(!fresh.service_sync_usage);
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -943,6 +943,32 @@ async testAgent(id: string, sampleText: string) : Promise<Result<AgentTestResult
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Fetch and resolve a remote agent's card, PERSIST the resolved endpoint +
+ * display metadata onto the agent, and return a summary for the UI. This is the
+ * settings "Fetch card" button.
+ */
+async fetchRemoteAgentCard(agentId: string) : Promise<Result<AgentCardSummary, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("fetch_remote_agent_card", { agentId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Lightweight reachability test: re-fetch the card (with the 401→token retry).
+ * Deliberately does NOT send a real message — that could cost money or trigger
+ * real work on the user's server. Returns the resolved endpoint on success.
+ */
+async testRemoteAgent(agentId: string) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("test_remote_agent", { agentId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async createAiMode(mode: AiMode) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_ai_mode", { mode }) };
@@ -1633,6 +1659,16 @@ export type AgentBinaryTest = { ok: boolean; output: string;
  * message (e.g. a broken Codex install). `None` for ordinary output.
  */
 hint: AgentBinaryHint | null }
+export type AgentCardSkill = { id: string; name: string }
+/**
+ * UI-facing summary returned by `fetch_remote_agent_card` / persisted on the agent.
+ */
+export type AgentCardSummary = { name: string; version: string; streaming: boolean; 
+/**
+ * The resolved JSON-RPC endpoint (empty only if selection somehow failed —
+ * callers error out before building a summary in that case).
+ */
+endpoint: string; auth_schemes: string[]; skills: AgentCardSkill[] }
 /**
  * Which local coding-agent CLI a `Cli` agent drives. Selects the prefilled
  * invocation template (see `default_command_template_for`). `Custom` is a
@@ -1697,15 +1733,41 @@ output_sinks?: AgentOutputSink[];
 /**
  * How the instruction reaches the CLI. `Stdin` (default) or `Arg`.
  */
-prompt_via?: PromptDelivery }
+prompt_via?: PromptDelivery; 
+/**
+ * The A2A agent's base URL as entered by the user. We derive
+ * `<origin>/.well-known/agent-card.json`; a full `…/agent-card.json` URL is
+ * accepted verbatim. Only meaningful when `kind == Remote`.
+ */
+remote_url?: string; 
+/**
+ * The resolved JSON-RPC endpoint URL from the agent card, cached at fetch
+ * time. Empty until the first successful `fetch_remote_agent_card`.
+ */
+remote_endpoint?: string; 
+/**
+ * Display name cached from the agent card.
+ */
+remote_card_name?: string; 
+/**
+ * Version cached from the agent card.
+ */
+remote_card_version?: string; 
+/**
+ * Card `capabilities.streaming`, cached — whether we may use `message/stream`.
+ */
+remote_streaming?: boolean }
 /**
  * Flow OS increment 2 — what KIND of agent this is. `Prompt` is the increment-1
  * behavior (dictation routed through a persona LLM before injection). `Cli`
  * drives a REAL local coding-agent binary (Claude Code, Codex, …) as a
- * subprocess in a chosen project folder. Defaults to `Prompt` so every agent
- * stored before this field existed stays a prompt agent, byte-for-byte.
+ * subprocess in a chosen project folder. `Remote` (increment 3) drives a
+ * spec-compliant **A2A** server the user points OpenFlow at (their VPS agent, a
+ * hosted flow, any endpoint) over the A2A JSON-RPC binding. Defaults to
+ * `Prompt` so every agent stored before this field existed stays a prompt
+ * agent, byte-for-byte.
  */
-export type AgentKind = "prompt" | "cli"
+export type AgentKind = "prompt" | "cli" | "remote"
 /**
  * What an agent does with its LLM response. `Inject` pastes it at the cursor
  * exactly like a normal dictation; `Clipboard` only copies it (no paste, no

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1493,6 +1493,78 @@ async downloadDiarizationModels() : Promise<Result<null, string>> {
 }
 },
 /**
+ * Pair this device with a self-hosted OpenFlow Service.
+ * 
+ * On `201`: store the returned `device_token` in the OS keyring, persist the URL,
+ * set `service_enabled = true`, record the device identity, and start the sync
+ * worker. On any error: friendly message, nothing persisted.
+ */
+async pairService(url: string, setupToken: string) : Promise<Result<PairedDeviceInfo, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("pair_service", { url, setupToken }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Unpair: best-effort revoke on the server, then remove the local token and
+ * disable the feature. Always succeeds locally even if the server is unreachable.
+ */
+async unpairService() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("unpair_service") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Current status for the settings UI.
+ */
+async serviceStatus() : Promise<Result<ServiceStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("service_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Test the connection with the stored token: `GET /v1/info`.
+ */
+async testServiceConnection() : Promise<Result<ServiceInfo, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("test_service_connection") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Toggle transcript sync (privacy-critical opt-in). Also nudges the worker so a
+ * freshly-enabled sync starts promptly.
+ */
+async setServiceSyncTranscripts(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_service_sync_transcripts", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Toggle usage-event sync (counts/durations only — never text).
+ */
+async setServiceSyncUsage(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_service_sync_usage", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Checks if the Mac is a laptop by detecting battery presence
  * 
  * This uses pmset to check for battery information.
@@ -1941,7 +2013,33 @@ meetings_diarization?: boolean;
  * infeasible past a few minutes, so the safe default is final-pass-only
  * (DESIGN-meetings.md §5.4 auto-degrade). Users on fast machines can opt in.
  */
-meetings_diarization_provisional?: boolean }
+meetings_diarization_provisional?: boolean; 
+/**
+ * Base URL of the paired self-hosted OpenFlow Service (e.g.
+ * `https://openflow.example.com`). Empty = feature fully dormant: no sync
+ * worker is ever started and nothing leaves the machine. The device token
+ * itself is NEVER stored here — it lives in the OS keyring (scope
+ * `"service"`, account `"device_token"`); this struct only holds the URL and
+ * opt-in flags. All four fields are `#[serde(default)]` so an old settings
+ * store (with none of these keys) deserializes byte-for-byte as before.
+ */
+service_url?: string; 
+/**
+ * Whether a device is paired and the integration is active. Set true only on
+ * a successful `pair_service`; cleared by `unpair_service`. When false the
+ * sync worker does nothing even if a URL is present.
+ */
+service_enabled?: boolean; 
+/**
+ * Opt-in: push dictation transcript TEXT to the service. Default OFF. When
+ * false, transcript text NEVER leaves the machine (privacy rule).
+ */
+service_sync_transcripts?: boolean; 
+/**
+ * Opt-in: push usage events (dictation counts/durations, NO text) to the
+ * service. Default OFF. Independent of `service_sync_transcripts`.
+ */
+service_sync_usage?: boolean }
 export type AppUsage = { app: string; dictations: number; words: number }
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
@@ -2184,6 +2282,10 @@ export type OverlayPosition = "top" | "bottom"
  */
 export type OverlayStyle = "none" | "minimal" | "live"
 export type PaginatedHistory = { entries: HistoryEntry[]; has_more: boolean }
+/**
+ * Returned to the UI after a successful pairing.
+ */
+export type PairedDeviceInfo = { device_id: string; device_name: string; url: string }
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v" | "external_script"
 export type PermissionAccess = "allowed" | "denied" | "unknown"
 export type PostProcessProvider = { id: string; label: string; base_url: string; allow_base_url_edit?: boolean; models_endpoint?: string | null; supports_structured_output?: boolean }
@@ -2207,6 +2309,30 @@ export type RunStatus = { status: "running" } | { status: "finished"; code: numb
  */
 export type RunningApp = { bundle_id: string; name: string }
 export type SecretMap = Partial<{ [key in string]: string }>
+/**
+ * Typed result of a connection test / info fetch.
+ */
+export type ServiceInfo = { version: string; edition: string; module_stt: boolean; module_llm: boolean; module_memory: boolean }
+/**
+ * Status snapshot for the settings UI.
+ */
+export type ServiceStatus = { 
+/**
+ * A URL is configured (feature is at least half-set-up).
+ */
+configured: boolean; 
+/**
+ * A device is paired and the integration is active.
+ */
+enabled: boolean; url: string; sync_transcripts: boolean; sync_usage: boolean; paired_device_name: string | null; 
+/**
+ * Unix seconds of the last successful push, if any.
+ */
+last_sync_at: number | null; 
+/**
+ * History rows not yet synced (informational).
+ */
+pending_count: number | null }
 export type ShortcutBinding = { id: string; name: string; description: string; default_binding: string; current_binding: string }
 export type SoundTheme = "marimba" | "pop" | "custom"
 /**

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   BookA,
   Radar,
   Video,
+  Cloud,
 } from "lucide-react";
 import { useSettings } from "../hooks/useSettings";
 import openflowLogo from "../assets/openflow-logo.png";
@@ -35,6 +36,7 @@ import {
   AgentRunsSettings,
   MissionControlSettings,
   MeetingsSettings,
+  ServiceSettings,
 } from "./settings";
 
 export type SidebarSection = keyof typeof SECTIONS_CONFIG;
@@ -167,6 +169,13 @@ export const SECTIONS_CONFIG = {
     group: "meetings",
   },
   // --- System ---
+  service: {
+    labelKey: "sidebar.service",
+    icon: Cloud,
+    component: ServiceSettings,
+    enabled: () => true,
+    group: "system",
+  },
   handsFree: {
     labelKey: "sidebar.handsFree",
     icon: Ear,

--- a/src/components/settings/agents/AgentCard.tsx
+++ b/src/components/settings/agents/AgentCard.tsx
@@ -20,6 +20,7 @@ import { AgentApiKeyField } from "./AgentApiKeyField";
 import { AgentTestPanel } from "./AgentTestPanel";
 import { AgentInlineToggle } from "./AgentInlineToggle";
 import { CliAgentCard } from "./CliAgentCard";
+import { RemoteAgentCard } from "./RemoteAgentCard";
 
 interface AgentCardProps {
   agent: AgentDefinition;
@@ -37,6 +38,14 @@ export const AgentCard: React.FC<AgentCardProps> = ({ agent, providers }) => {
   // increment-1 agents.
   if (agent.kind === "cli") {
     return <CliAgentCard agent={agent} />;
+  }
+
+  // Remote (A2A) agents (increment 3) render their own card — the prompt-agent
+  // fields below don't apply. Like `cli`, `kind` defaults to "prompt" for every
+  // agent stored before this discriminator existed, so this never affects
+  // increment-1 agents.
+  if (agent.kind === "remote") {
+    return <RemoteAgentCard agent={agent} />;
   }
 
   const [pending, setPending] = useState<Record<string, boolean>>({});

--- a/src/components/settings/agents/AgentsSettings.tsx
+++ b/src/components/settings/agents/AgentsSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { Bot, Plus, Terminal } from "lucide-react";
+import { Bot, Plus, RadioTower, Terminal } from "lucide-react";
 import type { AgentCliType, AgentDefinition } from "@/bindings";
 import { commands } from "@/bindings";
 import { useSettings } from "../../../hooks/useSettings";
@@ -134,6 +134,38 @@ export const AgentsSettings: React.FC = () => {
     }
   };
 
+  const handleAddRemote = async () => {
+    setCreatingKey("remote");
+    try {
+      const name = t("settings.agents.addAgent.remoteAgent");
+      const existingIds = new Set(agents.map((agent) => agent.id));
+      const id = uniqueAgentId(slugify(name), existingIds);
+
+      const result = await commands.createAgent({
+        id,
+        name,
+        binding_id: `agent:${id}`,
+        provider_id: "",
+        kind: "remote",
+        remote_url: "",
+        output_sinks: ["panel"],
+        enabled: true,
+      });
+
+      if (result.status === "error") {
+        toast.error(
+          t("settings.agents.addAgent.error", { error: result.error }),
+        );
+        return;
+      }
+
+      await refreshSettings();
+      toast.success(t("settings.agents.addAgent.created", { name }));
+    } finally {
+      setCreatingKey(null);
+    }
+  };
+
   return (
     <div className="max-w-3xl w-full mx-auto space-y-6">
       <SettingsGroup title={t("settings.agents.title")}>
@@ -194,6 +226,26 @@ export const AgentsSettings: React.FC = () => {
               >
                 <Terminal className="h-4 w-4" />
                 {t("settings.agents.addAgent.cliAgent")}
+              </Button>
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs font-medium text-mid-gray uppercase tracking-wide mb-2">
+              {t("settings.agents.addAgent.remoteSectionTitle")}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                size="md"
+                onClick={() => void handleAddRemote()}
+                disabled={creatingKey !== null}
+                className="inline-flex items-center gap-1.5"
+                title={t("settings.agents.addAgent.remoteDescription")}
+              >
+                <RadioTower className="h-4 w-4" />
+                {t("settings.agents.addAgent.remoteAgent")}
               </Button>
             </div>
           </div>

--- a/src/components/settings/agents/RemoteAgentCard.tsx
+++ b/src/components/settings/agents/RemoteAgentCard.tsx
@@ -1,0 +1,408 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { RadioTower, Trash2, Zap } from "lucide-react";
+import type {
+  AgentCardSummary,
+  AgentDefinition,
+  AgentOutputSink,
+} from "@/bindings";
+import { commands } from "@/bindings";
+import { useSettings } from "../../../hooks/useSettings";
+import { Input } from "../../ui/Input";
+import { Button } from "../../ui/Button";
+import { Dialog } from "../../ui/Dialog";
+import { Alert } from "../../ui/Alert";
+import { SettingContainer } from "../../ui/SettingContainer";
+import { ShortcutInput } from "../ShortcutInput";
+import { AgentApiKeyField } from "./AgentApiKeyField";
+import { AgentInlineToggle } from "./AgentInlineToggle";
+
+interface RemoteAgentCardProps {
+  agent: AgentDefinition;
+}
+
+const OUTPUT_SINKS: AgentOutputSink[] = ["panel", "notify", "file"];
+
+/**
+ * Remote-agent card (Flow OS increment 3): configures a spec-compliant **A2A**
+ * server instead of a local CLI subprocess or a persona-LLM transform. Mirrors
+ * `CliAgentCard`'s layout/patterns (header row, `ShortcutInput`,
+ * `SettingContainer` rows, optimistic drafts committed via `commands.updateAgent`
+ * + `refreshSettings`, Alert-based status). The bearer token reuses
+ * `AgentApiKeyField` against keyring scope "agent"/agent id.
+ */
+export const RemoteAgentCard: React.FC<RemoteAgentCardProps> = ({ agent }) => {
+  const { t } = useTranslation();
+  const { refreshSettings } = useSettings();
+
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+  const [nameDraft, setNameDraft] = useState(agent.name);
+  const [urlDraft, setUrlDraft] = useState(agent.remote_url ?? "");
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const [card, setCard] = useState<AgentCardSummary | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => setNameDraft(agent.name), [agent.name]);
+  useEffect(() => setUrlDraft(agent.remote_url ?? ""), [agent.remote_url]);
+
+  const isPending = (field: string) => pending[field] ?? false;
+
+  const persist = async (
+    patch: Partial<AgentDefinition>,
+    field: string,
+  ): Promise<boolean> => {
+    setPending((prev) => ({ ...prev, [field]: true }));
+    try {
+      const result = await commands.updateAgent({ ...agent, ...patch });
+      if (result.status === "error") {
+        toast.error(
+          t("settings.agents.card.update.error", { error: result.error }),
+        );
+        return false;
+      }
+      await refreshSettings();
+      return true;
+    } finally {
+      setPending((prev) => ({ ...prev, [field]: false }));
+    }
+  };
+
+  const commitName = () => {
+    const trimmed = nameDraft.trim();
+    if (!trimmed) {
+      setNameDraft(agent.name);
+      return;
+    }
+    if (trimmed === agent.name) return;
+    void persist({ name: trimmed }, "name");
+  };
+
+  const commitUrl = () => {
+    const trimmed = urlDraft.trim();
+    if (trimmed === (agent.remote_url ?? "")) return;
+    // Changing the URL invalidates the cached endpoint/card metadata.
+    void persist(
+      {
+        remote_url: trimmed,
+        remote_endpoint: "",
+        remote_card_name: "",
+        remote_card_version: "",
+        remote_streaming: false,
+      },
+      "remote_url",
+    );
+    setCard(null);
+    setFetchError(null);
+  };
+
+  const handleFetchCard = async () => {
+    // Persist any pending URL edit first so the backend fetches the right one.
+    const trimmed = urlDraft.trim();
+    if (trimmed !== (agent.remote_url ?? "")) {
+      const ok = await persist(
+        {
+          remote_url: trimmed,
+          remote_endpoint: "",
+          remote_card_name: "",
+          remote_card_version: "",
+          remote_streaming: false,
+        },
+        "remote_url",
+      );
+      if (!ok) return;
+    }
+    setPending((prev) => ({ ...prev, fetch: true }));
+    setFetchError(null);
+    try {
+      const result = await commands.fetchRemoteAgentCard(agent.id);
+      if (result.status === "error") {
+        setCard(null);
+        setFetchError(result.error);
+        return;
+      }
+      setCard(result.data);
+      await refreshSettings();
+    } catch (err) {
+      setCard(null);
+      setFetchError(String(err));
+    } finally {
+      setPending((prev) => ({ ...prev, fetch: false }));
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      const result = await commands.deleteAgent(agent.id);
+      if (result.status === "error") {
+        toast.error(
+          t("settings.agents.card.delete.error", { error: result.error }),
+        );
+        return;
+      }
+      await refreshSettings();
+      toast.success(
+        t("settings.agents.card.delete.success", { name: agent.name }),
+      );
+      setConfirmingDelete(false);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const toggleOutputSink = (sink: AgentOutputSink) => {
+    const current = agent.output_sinks ?? ["panel"];
+    const has = current.includes(sink);
+    let next: AgentOutputSink[];
+    if (has) {
+      // An agent must always land its output somewhere (defaults to Panel).
+      if (current.length <= 1) return;
+      next = current.filter((s) => s !== sink);
+    } else {
+      next = [...current, sink];
+    }
+    void persist({ output_sinks: next }, "output_sinks");
+  };
+
+  const activeOutputSinks = agent.output_sinks ?? ["panel"];
+
+  // Prefer the just-fetched summary; fall back to what's cached on the agent so
+  // a previously-fetched card still shows after a reload.
+  const cardName = card?.name ?? agent.remote_card_name ?? "";
+  const cardVersion = card?.version ?? agent.remote_card_version ?? "";
+  const cardStreaming = card?.streaming ?? agent.remote_streaming ?? false;
+  const cardEndpoint = card?.endpoint ?? agent.remote_endpoint ?? "";
+  const hasCard = cardName.length > 0 || cardEndpoint.length > 0;
+
+  return (
+    <div className="bg-background border border-mid-gray/20 rounded-lg divide-y divide-mid-gray/20">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Input
+          type="text"
+          variant="compact"
+          value={nameDraft}
+          disabled={isPending("name")}
+          onChange={(event) => setNameDraft(event.target.value)}
+          onBlur={commitName}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              event.currentTarget.blur();
+            }
+          }}
+          placeholder={t("settings.agents.card.name.placeholder")}
+          className="flex-1 min-w-0 font-semibold"
+          aria-label={t("settings.agents.card.name.label")}
+        />
+        <AgentInlineToggle
+          checked={agent.enabled ?? true}
+          disabled={isPending("enabled")}
+          onChange={(checked) => void persist({ enabled: checked }, "enabled")}
+          label={t("settings.agents.card.enabled.label")}
+        />
+        <Button
+          type="button"
+          variant="danger-ghost"
+          size="sm"
+          onClick={() => setConfirmingDelete(true)}
+          aria-label={t("settings.agents.card.delete.button")}
+          title={t("settings.agents.card.delete.button")}
+          className="shrink-0"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <ShortcutInput shortcutId={agent.binding_id} grouped />
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.url.label")}
+        description={t("settings.agents.card.remote.url.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="stacked"
+      >
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            variant="compact"
+            value={urlDraft}
+            disabled={isPending("remote_url")}
+            onChange={(event) => setUrlDraft(event.target.value)}
+            onBlur={commitUrl}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                event.currentTarget.blur();
+              }
+            }}
+            placeholder={t("settings.agents.card.remote.url.placeholder")}
+            className="flex-1 min-w-0"
+            aria-label={t("settings.agents.card.remote.url.label")}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            size="md"
+            onClick={() => void handleFetchCard()}
+            disabled={isPending("fetch") || !urlDraft.trim()}
+            className="inline-flex shrink-0 items-center gap-1.5"
+          >
+            <RadioTower className="h-4 w-4" />
+            {isPending("fetch")
+              ? t("settings.agents.card.remote.fetch.fetching")
+              : t("settings.agents.card.remote.fetch.button")}
+          </Button>
+        </div>
+      </SettingContainer>
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.token.label")}
+        description={t("settings.agents.card.remote.token.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="horizontal"
+      >
+        <AgentApiKeyField agentId={agent.id} />
+      </SettingContainer>
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.fetch.label")}
+        description={t("settings.agents.card.remote.fetch.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="stacked"
+      >
+        <div className="space-y-2">
+          {fetchError && (
+            <Alert variant="error" contained>
+              {t("settings.agents.card.remote.fetch.error", {
+                error: fetchError,
+              })}
+            </Alert>
+          )}
+          {!fetchError && hasCard && (
+            <Alert variant="success" contained>
+              <div className="space-y-1.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-semibold">{cardName}</span>
+                  {cardVersion && (
+                    <span className="text-xs text-mid-gray">
+                      {t("settings.agents.card.remote.fetch.version", {
+                        version: cardVersion,
+                      })}
+                    </span>
+                  )}
+                  {cardStreaming && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-background-ui/60 px-2 py-0.5 text-xs">
+                      <Zap className="h-3 w-3" />
+                      {t("settings.agents.card.remote.fetch.streaming")}
+                    </span>
+                  )}
+                </div>
+                {cardEndpoint && (
+                  <p
+                    className="truncate text-xs text-mid-gray"
+                    title={cardEndpoint}
+                  >
+                    {t("settings.agents.card.remote.fetch.endpoint", {
+                      endpoint: cardEndpoint,
+                    })}
+                  </p>
+                )}
+                {card?.auth_schemes && card.auth_schemes.length > 0 && (
+                  <p className="text-xs text-mid-gray">
+                    {t("settings.agents.card.remote.fetch.auth", {
+                      schemes: card.auth_schemes.join(", "),
+                    })}
+                  </p>
+                )}
+                {card?.skills && card.skills.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 pt-0.5">
+                    {card.skills.map((skill) => (
+                      <span
+                        key={skill.id}
+                        className="rounded-full bg-background-ui/60 px-2 py-0.5 text-xs"
+                        title={skill.id}
+                      >
+                        {skill.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </Alert>
+          )}
+          {!fetchError && !hasCard && (
+            <p className="text-sm text-mid-gray">
+              {t("settings.agents.card.remote.fetch.notFetched")}
+            </p>
+          )}
+        </div>
+      </SettingContainer>
+
+      <SettingContainer
+        title={t("settings.agents.card.remote.outputSinks.label")}
+        description={t("settings.agents.card.remote.outputSinks.description")}
+        descriptionMode="tooltip"
+        grouped
+        layout="horizontal"
+      >
+        <div className="flex items-center gap-3">
+          {OUTPUT_SINKS.map((sink) => (
+            <label
+              key={sink}
+              className="flex items-center gap-1.5 text-sm cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={activeOutputSinks.includes(sink)}
+                disabled={isPending("output_sinks")}
+                onChange={() => toggleOutputSink(sink)}
+                className="h-4 w-4 rounded border-mid-gray/80 accent-background-ui"
+              />
+              {t(`settings.agents.card.remote.outputSinks.${sink}`)}
+            </label>
+          ))}
+        </div>
+      </SettingContainer>
+
+      <Dialog
+        open={confirmingDelete}
+        onOpenChange={setConfirmingDelete}
+        title={t("settings.agents.card.delete.confirmTitle", {
+          name: agent.name,
+        })}
+        description={t("settings.agents.card.delete.confirmDescription")}
+        closeLabel={t("settings.agents.card.delete.cancel")}
+        footer={
+          <>
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              onClick={() => setConfirmingDelete(false)}
+              disabled={isDeleting}
+            >
+              {t("settings.agents.card.delete.cancel")}
+            </Button>
+            <Button
+              type="button"
+              variant="danger"
+              size="md"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {t("settings.agents.card.delete.confirm")}
+            </Button>
+          </>
+        }
+      >
+        <></>
+      </Dialog>
+    </div>
+  );
+};

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -15,6 +15,7 @@ export { ModelSetupSettings } from "./model-setup/ModelSetupSettings";
 export { DashboardSettings } from "./dashboard/DashboardSettings";
 export { HandsFreeSettings } from "./hands-free/HandsFreeSettings";
 export { MissionControlSettings } from "./mission-control/MissionControlSettings";
+export { ServiceSettings } from "./service/ServiceSettings";
 
 // Individual setting components
 export { MicrophoneSelector } from "./MicrophoneSelector";

--- a/src/components/settings/service/ServiceSettings.tsx
+++ b/src/components/settings/service/ServiceSettings.tsx
@@ -1,0 +1,290 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Cloud, Link2, Loader2, ShieldCheck, Unlink } from "lucide-react";
+import type { ServiceStatus, ServiceInfo } from "@/bindings";
+import { commands } from "@/bindings";
+import { Button } from "../../ui/Button";
+import { Input } from "../../ui/Input";
+import { SettingsGroup } from "../../ui/SettingsGroup";
+import { ToggleSwitch } from "../../ui/ToggleSwitch";
+
+/**
+ * OpenFlow Service — "Connect to my service".
+ *
+ * Additive, dormant-by-default integration: pair this device with a self-hosted
+ * OpenFlow Service, then opt in (per data type) to sync dictation transcripts
+ * and/or usage events. Nothing leaves the machine until the user pairs AND turns
+ * a sync on. The device token lives in the OS keyring (backend); this UI only
+ * ever sees the URL, device name and opt-in flags.
+ */
+export const ServiceSettings: React.FC = () => {
+  const { t } = useTranslation();
+
+  const [status, setStatus] = useState<ServiceStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Unpaired-form state.
+  const [url, setUrl] = useState("");
+  const [setupToken, setSetupToken] = useState("");
+  const [pairing, setPairing] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [unpairing, setUnpairing] = useState(false);
+  const [info, setInfo] = useState<ServiceInfo | null>(null);
+
+  const refresh = useCallback(async () => {
+    const result = await commands.serviceStatus();
+    if (result.status === "ok") {
+      setStatus(result.data);
+      // Pre-fill the URL field from any previously-configured value.
+      setUrl((prev) => (prev.length === 0 ? result.data.url : prev));
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    void refresh().finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
+
+  const handlePair = async () => {
+    setPairing(true);
+    setInfo(null);
+    try {
+      const result = await commands.pairService(url.trim(), setupToken.trim());
+      if (result.status === "error") {
+        toast.error(result.error);
+        return;
+      }
+      toast.success(
+        t("settings.service.pairedToast", { name: result.data.device_name }),
+      );
+      setSetupToken("");
+      await refresh();
+    } finally {
+      setPairing(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setInfo(null);
+    try {
+      const result = await commands.testServiceConnection();
+      if (result.status === "error") {
+        toast.error(result.error);
+        return;
+      }
+      setInfo(result.data);
+      toast.success(
+        t("settings.service.testOk", { version: result.data.version }),
+      );
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleUnpair = async () => {
+    setUnpairing(true);
+    try {
+      const result = await commands.unpairService();
+      if (result.status === "error") {
+        toast.error(result.error);
+        return;
+      }
+      setInfo(null);
+      toast.success(t("settings.service.unpairedToast"));
+      await refresh();
+    } finally {
+      setUnpairing(false);
+    }
+  };
+
+  const handleToggleTranscripts = async (checked: boolean) => {
+    const result = await commands.setServiceSyncTranscripts(checked);
+    if (result.status === "error") {
+      toast.error(result.error);
+      return;
+    }
+    await refresh();
+  };
+
+  const handleToggleUsage = async (checked: boolean) => {
+    const result = await commands.setServiceSyncUsage(checked);
+    if (result.status === "error") {
+      toast.error(result.error);
+      return;
+    }
+    await refresh();
+  };
+
+  const paired = status?.enabled ?? false;
+
+  return (
+    <div className="max-w-3xl w-full mx-auto space-y-6">
+      <SettingsGroup
+        title={t("settings.service.title")}
+        description={t("settings.service.intro")}
+      >
+        {/* Privacy note — always visible. */}
+        <div className="px-4 py-3 flex items-start gap-2 text-xs text-mid-gray border-b border-mid-gray/15">
+          <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5 text-logo-primary" />
+          <span>{t("settings.service.privacyNote")}</span>
+        </div>
+
+        {loading ? (
+          <div className="px-4 py-6 flex items-center gap-2 text-sm text-mid-gray">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("settings.service.loading")}
+          </div>
+        ) : paired ? (
+          // ---- Paired state ----
+          <div className="px-4 py-4 space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <Cloud className="h-4 w-4 text-logo-primary" />
+                  {status?.paired_device_name ??
+                    t("settings.service.thisDevice")}
+                </div>
+                <p className="text-xs text-mid-gray truncate mt-0.5">
+                  {status?.url}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="danger-ghost"
+                size="sm"
+                onClick={() => void handleUnpair()}
+                disabled={unpairing}
+                className="inline-flex items-center gap-1.5"
+              >
+                {unpairing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Unlink className="h-4 w-4" />
+                )}
+                {t("settings.service.unpair")}
+              </Button>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => void handleTest()}
+                disabled={testing}
+                className="inline-flex items-center gap-1.5"
+              >
+                {testing && <Loader2 className="h-4 w-4 animate-spin" />}
+                {t("settings.service.testConnection")}
+              </Button>
+              {info && (
+                <span className="text-xs text-mid-gray">
+                  {t("settings.service.infoLine", {
+                    version: info.version,
+                    edition: info.edition,
+                  })}
+                </span>
+              )}
+            </div>
+          </div>
+        ) : (
+          // ---- Unpaired state ----
+          <div className="px-4 py-4 space-y-3">
+            <label className="block space-y-1">
+              <span className="text-xs font-medium text-mid-gray">
+                {t("settings.service.urlLabel")}
+              </span>
+              <Input
+                type="text"
+                inputMode="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder={t("settings.service.urlPlaceholder")}
+                variant="compact"
+                className="w-full"
+              />
+            </label>
+            <label className="block space-y-1">
+              <span className="text-xs font-medium text-mid-gray">
+                {t("settings.service.setupTokenLabel")}
+              </span>
+              <Input
+                type="password"
+                value={setupToken}
+                onChange={(e) => setSetupToken(e.target.value)}
+                placeholder={t("settings.service.setupTokenPlaceholder")}
+                variant="compact"
+                className="w-full"
+              />
+            </label>
+            <div className="flex items-center gap-2 pt-1">
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                onClick={() => void handlePair()}
+                disabled={
+                  pairing ||
+                  url.trim().length === 0 ||
+                  setupToken.trim().length === 0
+                }
+                className="inline-flex items-center gap-1.5"
+              >
+                {pairing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Link2 className="h-4 w-4" />
+                )}
+                {t("settings.service.pair")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </SettingsGroup>
+
+      {/* Sync options — only meaningful once paired. */}
+      {paired && (
+        <SettingsGroup title={t("settings.service.syncTitle")}>
+          <ToggleSwitch
+            checked={status?.sync_transcripts ?? false}
+            onChange={(checked) => void handleToggleTranscripts(checked)}
+            label={t("settings.service.syncTranscripts")}
+            description={t("settings.service.syncTranscriptsHint")}
+            descriptionMode="inline"
+            grouped
+          />
+          <ToggleSwitch
+            checked={status?.sync_usage ?? false}
+            onChange={(checked) => void handleToggleUsage(checked)}
+            label={t("settings.service.syncUsage")}
+            description={t("settings.service.syncUsageHint")}
+            descriptionMode="inline"
+            grouped
+          />
+          <div className="px-4 py-3 border-t border-mid-gray/15 flex items-center justify-between gap-3 text-xs text-mid-gray">
+            <span>
+              {status?.last_sync_at
+                ? t("settings.service.lastSync", {
+                    when: new Date(status.last_sync_at * 1000).toLocaleString(),
+                  })
+                : t("settings.service.neverSynced")}
+            </span>
+            <span className="tabular-nums">
+              {t("settings.service.pending", {
+                count: status?.pending_count ?? 0,
+              })}
+            </span>
+          </div>
+        </SettingsGroup>
+      )}
+    </div>
+  );
+};

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -33,7 +33,8 @@
       "agents": "Agents",
       "meetings": "Meetings",
       "system": "System"
-    }
+    },
+    "service": "OpenFlow Service"
   },
   "onboarding": {
     "subtitle": "To get started, choose a transcription model",
@@ -1308,6 +1309,32 @@
         "meetingCapture": "Meeting capture",
         "showHotkeys": "Show hotkeys"
       }
+    },
+    "service": {
+      "title": "OpenFlow Service",
+      "intro": "Connect this device to your own self-hosted OpenFlow Service to sync dictation history and usage across your machines.",
+      "privacyNote": "Nothing is sent unless you turn it on. Your service, your data.",
+      "loading": "Checking connection…",
+      "thisDevice": "This device",
+      "urlLabel": "Service URL",
+      "urlPlaceholder": "https://openflow.example.com",
+      "setupTokenLabel": "Setup token",
+      "setupTokenPlaceholder": "Paste the setup token from your service",
+      "pair": "Pair",
+      "unpair": "Unpair",
+      "testConnection": "Test connection",
+      "infoLine": "{{edition}} · v{{version}}",
+      "pairedToast": "Paired as {{name}}",
+      "unpairedToast": "This device has been unpaired.",
+      "testOk": "Connected to OpenFlow Service v{{version}}",
+      "syncTitle": "Sync",
+      "syncTranscripts": "Sync transcripts",
+      "syncTranscriptsHint": "Push dictation transcript text to your service. Off by default — when off, transcript text never leaves this machine.",
+      "syncUsage": "Sync usage",
+      "syncUsageHint": "Push usage events (dictation counts and durations only — never text) to your service.",
+      "lastSync": "Last sync: {{when}}",
+      "neverSynced": "Not synced yet",
+      "pending": "{{count}} pending"
     }
   },
   "footer": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -692,7 +692,10 @@
         "promptSectionTitle": "Prompt agents",
         "cliSectionTitle": "CLI agents",
         "cliAgent": "CLI agent",
-        "cliDescription": "Drive a real coding-agent CLI (Claude Code, Codex, …) as a subprocess in a project folder."
+        "cliDescription": "Drive a real coding-agent CLI (Claude Code, Codex, …) as a subprocess in a project folder.",
+        "remoteSectionTitle": "Remote agents",
+        "remoteAgent": "Remote agent (A2A)",
+        "remoteDescription": "Point a hotkey at any spec-compliant A2A server — your VPS agent, a hosted flow, any endpoint."
       },
       "card": {
         "name": {
@@ -803,6 +806,37 @@
             "placeholder": "e.g. -p --output-format stream-json --verbose",
             "show": "Show advanced",
             "hide": "Hide advanced"
+          },
+          "outputSinks": {
+            "label": "Output",
+            "description": "Where this run's output goes when it finishes.",
+            "panel": "Panel",
+            "notify": "Notify",
+            "file": "File"
+          }
+        },
+        "remote": {
+          "url": {
+            "label": "Agent URL",
+            "description": "The base URL of the A2A agent. OpenFlow reads its card from /.well-known/agent-card.json (or paste a full card URL).",
+            "placeholder": "e.g. https://agent.example.com"
+          },
+          "token": {
+            "label": "Token",
+            "description": "Optional bearer token sent with every request. Stored in your OS keychain, never in settings."
+          },
+          "fetch": {
+            "label": "Agent card",
+            "description": "Fetch the card to resolve the agent's JSON-RPC endpoint and capabilities.",
+            "button": "Fetch card",
+            "fetching": "Fetching…",
+            "error": "Couldn't fetch the card: {{error}}",
+            "notFetched": "No card fetched yet. Enter the URL above and fetch the card.",
+            "streaming": "Streaming",
+            "endpoint": "Endpoint: {{endpoint}}",
+            "version": "v{{version}}",
+            "skills": "Skills",
+            "auth": "Auth: {{schemes}}"
           },
           "outputSinks": {
             "label": "Output",


### PR DESCRIPTION
Recovers the remote-agents work from #58, which was auto-closed when #57's base branch `feat/service-connect-rebased` was deleted after squash-merge.

The 2 unique remote-agent commits from #58's head (`feat/remote-agents-rebased`) were rebased `--onto main`, dropping #57's service commit (already on main via squash `96c209c`). Diff is exactly the 13 remote-agent files.

Supersedes #58 (closed, base_ref_deleted).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>